### PR TITLE
Switch to generic BitVector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Introduced `IndexBuilder` trait with a `Built` type and adjusted serialization helpers.
 - Rename crate to `succdisk` to reflect on-disk succinct data structures.
 - Rename crate from `succdisk` to `jerky`.
+- Replaced the old `BitVector` with the generic `BitVector<I>` and renamed the
+  mutable variant to `RawBitVector`.

--- a/bench/benches/timing_bitvec_rank.rs
+++ b/bench/benches/timing_bitvec_rank.rs
@@ -39,7 +39,7 @@ fn run_queries<R: Rank>(idx: &R, queries: &[usize]) {
 
 fn perform_bitvec_rank(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], queries: &[usize]) {
     group.bench_function("jerky/BitVector", |b| {
-        let idx = jerky::bit_vectors::BitVector::from_bits(bits.iter().cloned());
+        let idx = jerky::bit_vectors::RawBitVector::from_bits(bits.iter().cloned());
         b.iter(|| run_queries(&idx, &queries));
     });
 

--- a/bench/benches/timing_bitvec_select.rs
+++ b/bench/benches/timing_bitvec_select.rs
@@ -43,7 +43,7 @@ fn run_queries<S: Select>(idx: &S, queries: &[usize]) {
 
 fn perform_bitvec_select(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], queries: &[usize]) {
     group.bench_function("jerky/BitVector", |b| {
-        let idx = jerky::bit_vectors::BitVector::from_bits(bits.iter().cloned());
+        let idx = jerky::bit_vectors::RawBitVector::from_bits(bits.iter().cloned());
         b.iter(|| run_queries(&idx, &queries));
     });
 

--- a/bench/benches/timing_chrseq_access.rs
+++ b/bench/benches/timing_chrseq_access.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
-use jerky::bit_vectors::{prelude::*, BitVector};
+use jerky::bit_vectors::{prelude::*, RawBitVector};
 use jerky::int_vectors::CompactVector;
 
 use criterion::{
@@ -24,7 +24,7 @@ const PROTEINS_PSEF_STR: &str = include_str!("../data/texts/proteins.1MiB.txt");
 // In effective alphabet
 fn load_text(s: &str) -> CompactVector {
     let mut text = s.as_bytes().to_vec();
-    let mut alphabet = BitVector::from_bit(false, 256);
+    let mut alphabet = RawBitVector::from_bit(false, 256);
     text.iter()
         .for_each(|&c| alphabet.set_bit(usize::from(c), true).unwrap());
     for i in 0..text.len() {

--- a/bench/src/mem_chrseq.rs
+++ b/bench/src/mem_chrseq.rs
@@ -1,4 +1,4 @@
-use jerky::bit_vectors::{BitVector, Rank};
+use jerky::bit_vectors::{Rank, RawBitVector};
 use jerky::int_vectors::CompactVector;
 
 const DBLP_PSEF_STR: &str = include_str!("../data/texts/dblp.1MiB.txt");
@@ -14,7 +14,7 @@ fn main() {
 // In effective alphabet
 fn load_text(s: &str) -> CompactVector {
     let mut text = s.as_bytes().to_vec();
-    let mut alphabet = BitVector::from_bit(false, 256);
+    let mut alphabet = RawBitVector::from_bit(false, 256);
     text.iter()
         .for_each(|&c| alphabet.set_bit(usize::from(c), true).unwrap());
     for i in 0..text.len() {

--- a/src/bit_vectors.rs
+++ b/src/bit_vectors.rs
@@ -82,11 +82,9 @@ pub mod data;
 pub mod prelude;
 pub mod rank9sel;
 
-pub use bit_vector::BitVector;
+pub use bit_vector::RawBitVector;
 pub use darray::DArray;
-pub use data::{
-    BitVector as IndexedBitVector, BitVectorData, BitVectorIndex, IndexBuilder, NoIndex,
-};
+pub use data::{BitVector, BitVectorData, BitVectorIndex, IndexBuilder, NoIndex};
 pub use rank9sel::Rank9Sel;
 
 use anyhow::Result;

--- a/src/bit_vectors/bit_vector.rs
+++ b/src/bit_vectors/bit_vector.rs
@@ -16,9 +16,9 @@ pub const WORD_LEN: usize = std::mem::size_of::<usize>() * 8;
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use jerky::bit_vectors::BitVector;
+/// use jerky::bit_vectors::RawBitVector;
 ///
-/// let mut bv = BitVector::new();
+/// let mut bv = RawBitVector::new();
 /// bv.push_bit(true);
 /// bv.push_bit(false);
 ///
@@ -35,20 +35,20 @@ pub const WORD_LEN: usize = std::mem::size_of::<usize>() * 8;
 ///
 /// This is a yet another Rust port of [succinct::bit_vector](https://github.com/ot/succinct/blob/master/bit_vector.hpp).
 #[derive(Default, Clone, PartialEq, Eq)]
-pub struct BitVector {
+pub struct RawBitVector {
     words: Vec<usize>,
     len: usize,
 }
 
-impl BitVector {
+impl RawBitVector {
     /// Creates a new empty vector.
     ///
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::new();
+    /// let bv = RawBitVector::new();
     /// assert_eq!(bv.len(), 0);
     /// ```
     pub fn new() -> Self {
@@ -64,9 +64,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::with_capacity(40);
+    /// let bv = RawBitVector::with_capacity(40);
     /// assert_eq!(bv.len(), 0);
     /// assert_eq!(bv.capacity(), 64);
     /// ```
@@ -88,9 +88,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bit(false, 5);
+    /// let bv = RawBitVector::from_bit(false, 5);
     /// assert_eq!(bv.len(), 5);
     /// assert_eq!(bv.get_bit(0), Some(false));
     /// ```
@@ -114,9 +114,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([false, true, false]);
+    /// let bv = RawBitVector::from_bits([false, true, false]);
     /// assert_eq!(bv.len(), 3);
     /// assert_eq!(bv.get_bit(1), Some(true));
     /// ```
@@ -138,9 +138,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([true, false, false]);
+    /// let bv = RawBitVector::from_bits([true, false, false]);
     /// assert_eq!(bv.get_bit(0), Some(true));
     /// assert_eq!(bv.get_bit(1), Some(false));
     /// assert_eq!(bv.get_bit(2), Some(false));
@@ -170,9 +170,9 @@ impl BitVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let mut bv = BitVector::from_bits([false, true, false]);
+    /// let mut bv = RawBitVector::from_bits([false, true, false]);
     /// bv.set_bit(1, false)?;
     /// assert_eq!(bv.get_bit(1), Some(false));
     /// # Ok(())
@@ -202,9 +202,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let mut bv = BitVector::new();
+    /// let mut bv = RawBitVector::new();
     /// bv.push_bit(true);
     /// bv.push_bit(false);
     /// assert_eq!(bv.len(), 2);
@@ -234,9 +234,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([true, false, true, false]);
+    /// let bv = RawBitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.get_bits(1, 2), Some(0b10));
     /// assert_eq!(bv.get_bits(2, 3), None);
     /// ```
@@ -288,9 +288,9 @@ impl BitVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let mut bv = BitVector::from_bit(false, 4);
+    /// let mut bv = RawBitVector::from_bit(false, 4);
     /// bv.set_bits(1, 0b11, 2)?;
     /// assert_eq!(bv.get_bits(0, 4), Some(0b0110));
     /// # Ok(())
@@ -358,9 +358,9 @@ impl BitVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let mut bv = BitVector::new();
+    /// let mut bv = RawBitVector::new();
     /// bv.push_bits(0b11, 2)?;
     /// bv.push_bits(0b101, 3)?;
     /// assert_eq!(bv.get_bits(0, 5), Some(0b10111));
@@ -415,9 +415,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([false, true, false, true]);
+    /// let bv = RawBitVector::from_bits([false, true, false, true]);
     /// assert_eq!(bv.predecessor1(3), Some(3));
     /// assert_eq!(bv.predecessor1(2), Some(1));
     /// assert_eq!(bv.predecessor1(1), Some(1));
@@ -455,9 +455,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([true, false, true, false]);
+    /// let bv = RawBitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.predecessor0(3), Some(3));
     /// assert_eq!(bv.predecessor0(2), Some(1));
     /// assert_eq!(bv.predecessor0(1), Some(1));
@@ -495,9 +495,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([true, false, true, false]);
+    /// let bv = RawBitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.successor1(0), Some(0));
     /// assert_eq!(bv.successor1(1), Some(2));
     /// assert_eq!(bv.successor1(2), Some(2));
@@ -536,9 +536,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([false, true, false, true]);
+    /// let bv = RawBitVector::from_bits([false, true, false, true]);
     /// assert_eq!(bv.successor0(0), Some(0));
     /// assert_eq!(bv.successor0(1), Some(2));
     /// assert_eq!(bv.successor0(2), Some(2));
@@ -568,9 +568,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([false, true, false]);
+    /// let bv = RawBitVector::from_bits([false, true, false]);
     /// let mut it = bv.iter();
     /// assert_eq!(it.next(), Some(false));
     /// assert_eq!(it.next(), Some(true));
@@ -590,9 +590,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([true, true, false, true]);
+    /// let bv = RawBitVector::from_bits([true, true, false, true]);
     /// let mut it = bv.unary_iter(1);
     /// assert_eq!(it.next(), Some(1));
     /// assert_eq!(it.next(), Some(3));
@@ -612,9 +612,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([true, false, true, false]);
+    /// let bv = RawBitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.get_word64(1), Some(0b10));
     /// assert_eq!(bv.get_bits(1, 64), None);  // out of bounds
     /// ```
@@ -668,7 +668,7 @@ impl BitVector {
     }
 }
 
-impl Build for BitVector {
+impl Build for RawBitVector {
     /// Creates a new vector from input bit stream `bits`.
     ///
     /// # Arguments
@@ -695,7 +695,7 @@ impl Build for BitVector {
     }
 }
 
-impl NumBits for BitVector {
+impl NumBits for RawBitVector {
     /// Returns the number of bits stored (just wrapping [`Self::len()`]).
     fn num_bits(&self) -> usize {
         self.len()
@@ -711,7 +711,7 @@ impl NumBits for BitVector {
     }
 }
 
-impl Access for BitVector {
+impl Access for RawBitVector {
     /// Returns the `pos`-th bit, or [`None`] if out of bounds.
     ///
     /// # Arguments
@@ -721,9 +721,9 @@ impl Access for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, Access};
+    /// use jerky::bit_vectors::{RawBitVector, Access};
     ///
-    /// let bv = BitVector::from_bits([true, false, false]);
+    /// let bv = RawBitVector::from_bits([true, false, false]);
     /// assert_eq!(bv.access(0), Some(true));
     /// assert_eq!(bv.access(1), Some(false));
     /// assert_eq!(bv.access(2), Some(false));
@@ -739,7 +739,7 @@ impl Access for BitVector {
     }
 }
 
-impl Rank for BitVector {
+impl Rank for RawBitVector {
     /// Returns the number of ones from the 0-th bit to the `pos-1`-th bit, or
     /// [`None`] if `self.len() < pos`.
     ///
@@ -750,9 +750,9 @@ impl Rank for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, Rank};
+    /// use jerky::bit_vectors::{RawBitVector, Rank};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.rank1(1), Some(1));
     /// assert_eq!(bv.rank1(2), Some(1));
     /// assert_eq!(bv.rank1(3), Some(1));
@@ -784,9 +784,9 @@ impl Rank for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, Rank};
+    /// use jerky::bit_vectors::{RawBitVector, Rank};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.rank0(1), Some(0));
     /// assert_eq!(bv.rank0(2), Some(1));
     /// assert_eq!(bv.rank0(3), Some(2));
@@ -798,7 +798,7 @@ impl Rank for BitVector {
     }
 }
 
-impl Select for BitVector {
+impl Select for RawBitVector {
     /// Searches the position of the `k`-th bit set, or
     /// [`None`] if `k` is no less than the number of ones.
     ///
@@ -809,9 +809,9 @@ impl Select for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, Select};
+    /// use jerky::bit_vectors::{RawBitVector, Select};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.select1(0), Some(0));
     /// assert_eq!(bv.select1(1), Some(3));
     /// assert_eq!(bv.select1(2), None);
@@ -845,9 +845,9 @@ impl Select for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, Select};
+    /// use jerky::bit_vectors::{RawBitVector, Select};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.select0(0), Some(1));
     /// assert_eq!(bv.select0(1), Some(2));
     /// assert_eq!(bv.select0(2), None);
@@ -874,15 +874,15 @@ impl Select for BitVector {
     }
 }
 
-/// Iterator for enumerating bits, created by [`BitVector::iter()`].
+/// Iterator for enumerating bits, created by [`RawBitVector::iter()`].
 pub struct Iter<'a> {
-    bv: &'a BitVector,
+    bv: &'a RawBitVector,
     pos: usize,
 }
 
 impl<'a> Iter<'a> {
     /// Creates a new iterator.
-    pub const fn new(bv: &'a BitVector) -> Self {
+    pub const fn new(bv: &'a RawBitVector) -> Self {
         Self { bv, pos: 0 }
     }
 }
@@ -907,7 +907,7 @@ impl Iterator for Iter<'_> {
     }
 }
 
-impl std::iter::Extend<bool> for BitVector {
+impl std::iter::Extend<bool> for RawBitVector {
     fn extend<I>(&mut self, bits: I)
     where
         I: IntoIterator<Item = bool>,
@@ -916,20 +916,20 @@ impl std::iter::Extend<bool> for BitVector {
     }
 }
 
-impl std::fmt::Debug for BitVector {
+impl std::fmt::Debug for RawBitVector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut bits = vec![0u8; self.len()];
         for (i, b) in bits.iter_mut().enumerate() {
             *b = self.access(i).unwrap() as u8;
         }
-        f.debug_struct("BitVector")
+        f.debug_struct("RawBitVector")
             .field("bits", &bits)
             .field("len", &self.len)
             .finish()
     }
 }
 
-impl BitVector {
+impl RawBitVector {
     /// Returns the number of bytes required for serializing this bit vector
     /// in the former copy-based format.
     pub fn size_in_bytes(&self) -> usize {
@@ -943,7 +943,7 @@ mod tests {
 
     #[test]
     fn test_set_bit_oob() {
-        let mut bv = BitVector::from_bit(false, 3);
+        let mut bv = RawBitVector::from_bit(false, 3);
         let e = bv.set_bit(3, true);
         assert_eq!(
             e.err().map(|x| x.to_string()),
@@ -953,7 +953,7 @@ mod tests {
 
     #[test]
     fn test_set_bits_over_word() {
-        let mut bv = BitVector::from_bit(false, 100);
+        let mut bv = RawBitVector::from_bit(false, 100);
         let e = bv.set_bits(0, 0b0, 65);
         assert_eq!(
             e.err().map(|x| x.to_string()),
@@ -963,7 +963,7 @@ mod tests {
 
     #[test]
     fn test_set_bits_oob() {
-        let mut bv = BitVector::from_bit(false, 3);
+        let mut bv = RawBitVector::from_bit(false, 3);
         let e = bv.set_bits(2, 0b11, 2);
         assert_eq!(
             e.err().map(|x| x.to_string()),
@@ -973,21 +973,21 @@ mod tests {
 
     #[test]
     fn test_set_bits_truncation() {
-        let mut bv = BitVector::from_bit(false, 3);
+        let mut bv = RawBitVector::from_bit(false, 3);
         bv.set_bits(0, 0b111, 2).unwrap();
-        assert_eq!(bv, BitVector::from_bits([true, true, false]));
+        assert_eq!(bv, RawBitVector::from_bits([true, true, false]));
     }
 
     #[test]
     fn test_set_bits_accross_word() {
-        let mut bv = BitVector::from_bit(false, 100);
+        let mut bv = RawBitVector::from_bit(false, 100);
         bv.set_bits(62, 0b11111, 5).unwrap();
         assert_eq!(bv.get_bits(61, 7).unwrap(), 0b0111110);
     }
 
     #[test]
     fn test_push_bits_over_word() {
-        let mut bv = BitVector::new();
+        let mut bv = RawBitVector::new();
         let e = bv.push_bits(0b0, 65);
         assert_eq!(
             e.err().map(|x| x.to_string()),
@@ -997,28 +997,28 @@ mod tests {
 
     #[test]
     fn test_push_bits_truncation() {
-        let mut bv = BitVector::new();
+        let mut bv = RawBitVector::new();
         bv.push_bits(0b111, 2).unwrap();
-        assert_eq!(bv, BitVector::from_bits([true, true]));
+        assert_eq!(bv, RawBitVector::from_bits([true, true]));
     }
 
     #[test]
     fn test_push_bits_accross_word() {
-        let mut bv = BitVector::from_bit(false, 62);
+        let mut bv = RawBitVector::from_bit(false, 62);
         bv.push_bits(0b011111, 6).unwrap();
         assert_eq!(bv.get_bits(61, 7).unwrap(), 0b0111110);
     }
 
     #[test]
     fn test_get_word64_oob() {
-        let bv = BitVector::from_bit(false, 3);
+        let bv = RawBitVector::from_bit(false, 3);
         assert_eq!(bv.get_word64(3), None);
     }
 
     #[test]
     fn test_get_word64_overflow() {
         // Test a case that can see the next block (but not exist).
-        let bv = BitVector::from_bit(true, 64);
+        let bv = RawBitVector::from_bit(true, 64);
         assert_eq!(bv.get_word64(60), Some(0b1111));
     }
 }

--- a/src/bit_vectors/bit_vector/unary.rs
+++ b/src/bit_vectors/bit_vector/unary.rs
@@ -1,19 +1,19 @@
 //! Unary iterator on bit vectors.
 use super::WORD_LEN;
-use crate::bit_vectors::BitVector;
 use crate::bit_vectors::NumBits;
+use crate::bit_vectors::RawBitVector;
 use crate::broadword;
 
-/// Iterator for enumerating positions of set bits, created by [`BitVector::unary_iter`].
+/// Iterator for enumerating positions of set bits, created by [`RawBitVector::unary_iter`].
 pub struct UnaryIter<'a> {
-    bv: &'a BitVector,
+    bv: &'a RawBitVector,
     pos: usize,
     buf: usize,
 }
 
 impl<'a> UnaryIter<'a> {
     /// Creates the iterator from the given bit position.
-    pub fn new(bv: &'a BitVector, pos: usize) -> Self {
+    pub fn new(bv: &'a RawBitVector, pos: usize) -> Self {
         let buf = bv.words()[pos / WORD_LEN] & (usize::MAX.wrapping_shl((pos % WORD_LEN) as u32));
         Self { bv, pos, buf }
     }
@@ -29,9 +29,9 @@ impl<'a> UnaryIter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([false, true, false, false, true, true]);
+    /// let bv = RawBitVector::from_bits([false, true, false, false, true, true]);
     /// let mut it = bv.unary_iter(0);
     ///
     /// assert_eq!(it.skip1(0), Some(1));
@@ -67,9 +67,9 @@ impl<'a> UnaryIter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::RawBitVector;
     ///
-    /// let bv = BitVector::from_bits([false, true, false, false, true, true]);
+    /// let bv = RawBitVector::from_bits([false, true, false, false, true, true]);
     /// let mut it = bv.unary_iter(0);
     ///
     /// assert_eq!(it.skip0(0), Some(0));
@@ -129,21 +129,21 @@ mod tests {
 
     #[test]
     fn test_next_all_zeros() {
-        let bv = BitVector::from_bit(false, 100);
+        let bv = RawBitVector::from_bit(false, 100);
         let mut it = bv.unary_iter(0);
         assert_eq!(it.next(), None);
     }
 
     #[test]
     fn test_skip1_all_zeros() {
-        let bv = BitVector::from_bit(false, 100);
+        let bv = RawBitVector::from_bit(false, 100);
         let mut it = bv.unary_iter(0);
         assert_eq!(it.skip1(0), None);
     }
 
     #[test]
     fn test_skip0_all_ones() {
-        let bv = BitVector::from_bit(true, 100);
+        let bv = RawBitVector::from_bit(true, 100);
         let mut it = bv.unary_iter(0);
         assert_eq!(it.skip0(0), None);
     }

--- a/src/bit_vectors/darray.rs
+++ b/src/bit_vectors/darray.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use crate::bit_vectors::data::BitVectorData;
 use crate::bit_vectors::prelude::*;
 use crate::bit_vectors::rank9sel::inner::Rank9SelIndex;
-use crate::bit_vectors::BitVector;
+use crate::bit_vectors::RawBitVector;
 use inner::{DArrayIndex, DArrayIndexBuilder};
 
 /// Constant-time select data structure over integer sets with the dense array technique.
@@ -54,7 +54,7 @@ use inner::{DArrayIndex, DArrayIndexBuilder};
 ///    In ALENEX, 2007.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct DArray {
-    bv: BitVector,
+    bv: RawBitVector,
     s1: DArrayIndex<true>,
     s0: Option<DArrayIndex<false>>,
     r9: Option<Rank9SelIndex>,
@@ -70,7 +70,7 @@ impl DArray {
     where
         I: IntoIterator<Item = bool>,
     {
-        let bv = BitVector::from_bits(bits);
+        let bv = RawBitVector::from_bits(bits);
         let s1 = DArrayIndexBuilder::<true>::from_raw(&bv).build();
         Self {
             bv,
@@ -107,7 +107,7 @@ impl DArray {
     }
 
     /// Returns the reference of the internal bit vector.
-    pub const fn bit_vector(&self) -> &BitVector {
+    pub const fn bit_vector(&self) -> &RawBitVector {
         &self.bv
     }
 

--- a/src/bit_vectors/darray/inner.rs
+++ b/src/bit_vectors/darray/inner.rs
@@ -6,7 +6,7 @@ use anybytes::{Bytes, View};
 use anyhow::Result;
 
 use crate::bit_vectors::data::BitVectorData;
-use crate::bit_vectors::BitVector;
+use crate::bit_vectors::RawBitVector;
 use crate::bit_vectors::{Access, NumBits};
 use crate::broadword;
 
@@ -109,8 +109,8 @@ impl<const OVER_ONE: bool> DArrayIndexBuilder<OVER_ONE> {
         }
     }
 
-    /// Creates a builder from a raw [`BitVector`].
-    pub fn from_raw(bv: &BitVector) -> Self {
+    /// Creates a builder from a raw [`RawBitVector`].
+    pub fn from_raw(bv: &RawBitVector) -> Self {
         let data = BitVectorData::from(bv.clone());
         Self::new(&data)
     }
@@ -145,8 +145,8 @@ impl<const OVER_ONE: bool> DArrayIndex<OVER_ONE> {
         DArrayIndexBuilder::<OVER_ONE>::new(data).build()
     }
 
-    /// Creates a new index from a raw [`BitVector`].
-    pub fn from_raw(bv: &BitVector) -> Self {
+    /// Creates a new index from a raw [`RawBitVector`].
+    pub fn from_raw(bv: &RawBitVector) -> Self {
         let data = BitVectorData::from(bv.clone());
         Self::new(&data)
     }
@@ -169,9 +169,9 @@ impl<const OVER_ONE: bool> DArrayIndex<OVER_ONE> {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, darray::inner::DArrayIndex};
+    /// use jerky::bit_vectors::{RawBitVector, darray::inner::DArrayIndex};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// let da = DArrayIndex::<true>::from_raw(&bv);
     /// let data = jerky::bit_vectors::BitVectorData::from(bv.clone());
     /// assert_eq!(da.select(&data, 0), Some(0));
@@ -183,9 +183,9 @@ impl<const OVER_ONE: bool> DArrayIndex<OVER_ONE> {
     /// `DArrayIndex::<false>::from_raw(&bv)`.
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, darray::inner::DArrayIndex};
+    /// use jerky::bit_vectors::{RawBitVector, darray::inner::DArrayIndex};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// let da = DArrayIndex::<false>::from_raw(&bv);
     /// let data = jerky::bit_vectors::BitVectorData::from(bv.clone());
     /// assert_eq!(da.select(&data, 0), Some(1));
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_all_zeros_index() {
-        let bv = BitVector::from_bit(false, 3);
+        let bv = RawBitVector::from_bit(false, 3);
         let da = DArrayIndex::<true>::from_raw(&bv);
         let data = BitVectorData::from(bv);
         assert_eq!(da.select(&data, 0), None);
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_all_ones_index() {
-        let bv = BitVector::from_bit(true, 3);
+        let bv = RawBitVector::from_bit(true, 3);
         let da = DArrayIndex::<false>::from_raw(&bv);
         let data = BitVectorData::from(bv);
         assert_eq!(da.select(&data, 0), None);
@@ -424,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_zero_copy_from_to_bytes() {
-        let bv = BitVector::from_bits([true, false, true, false, true]);
+        let bv = RawBitVector::from_bits([true, false, true, false, true]);
         let idx = DArrayIndex::<true>::from_raw(&bv);
         let bytes = idx.to_bytes();
         let other = DArrayIndex::from_bytes(bytes).unwrap();
@@ -433,7 +433,7 @@ mod tests {
 
     #[test]
     fn test_builder_roundtrip() {
-        let bv = BitVector::from_bits([true, false, true, true, false, false]);
+        let bv = RawBitVector::from_bits([true, false, true, true, false, false]);
         let builder = DArrayIndexBuilder::<true>::from_raw(&bv);
         let idx = builder.clone().build();
         let bytes = builder.build().to_bytes();

--- a/src/bit_vectors/data.rs
+++ b/src/bit_vectors/data.rs
@@ -5,8 +5,7 @@
 //! reconstructed directly from [`anybytes::Bytes`] obtained via an mmap
 //! wrapper like `Bytes::from_source`.
 
-use crate::bit_vectors::bit_vector::BitVector as RawBitVector;
-use crate::bit_vectors::bit_vector::WORD_LEN;
+use crate::bit_vectors::bit_vector::{RawBitVector, WORD_LEN};
 use crate::bit_vectors::{Access, NumBits, Rank, Select};
 use anybytes::{Bytes, View};
 use anyhow::Result;

--- a/src/bit_vectors/rank9sel.rs
+++ b/src/bit_vectors/rank9sel.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 
 use crate::bit_vectors::data::BitVectorData;
 use crate::bit_vectors::prelude::*;
-use crate::bit_vectors::BitVector;
+use crate::bit_vectors::RawBitVector;
 use inner::{Rank9SelIndex, Rank9SelIndexBuilder};
 
 /// Rank/select data structure over bit vectors with Vigna's rank9 and hinted selection techniques.
 ///
-/// This builds rank/select indices on [`BitVector`] taking
+/// This builds rank/select indices on [`RawBitVector`] taking
 ///
 /// - 25% overhead of space for the rank index, and
 /// - 3% overhead of space for the select index (together with the rank's overhead).
@@ -57,13 +57,13 @@ use inner::{Rank9SelIndex, Rank9SelIndexBuilder};
 ///  - S. Vigna, "Broadword implementation of rank/select queries," In WEA, 2008.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rank9Sel {
-    bv: BitVector,
+    bv: RawBitVector,
     rs: Rank9SelIndex,
 }
 
 impl Rank9Sel {
     /// Creates a new vector from input bit vector `bv`.
-    pub fn new(bv: BitVector) -> Self {
+    pub fn new(bv: RawBitVector) -> Self {
         let rs = Rank9SelIndex::from_raw(&bv);
         Self { bv, rs }
     }
@@ -77,11 +77,11 @@ impl Rank9Sel {
     where
         I: IntoIterator<Item = bool>,
     {
-        Self::new(BitVector::from_bits(bits))
+        Self::new(RawBitVector::from_bits(bits))
     }
 
     /// Returns the reference of the internal bit vector.
-    pub const fn bit_vector(&self) -> &BitVector {
+    pub const fn bit_vector(&self) -> &RawBitVector {
         &self.bv
     }
 
@@ -124,7 +124,7 @@ impl Build for Rank9Sel {
         I: IntoIterator<Item = bool>,
         Self: Sized,
     {
-        let bv = BitVector::from_bits(bits);
+        let bv = RawBitVector::from_bits(bits);
         let mut builder = Rank9SelIndexBuilder::from_raw(&bv);
         if with_select1 {
             builder = builder.select1_hints();

--- a/src/bit_vectors/rank9sel/inner.rs
+++ b/src/bit_vectors/rank9sel/inner.rs
@@ -6,8 +6,8 @@ use anybytes::{Bytes, View};
 use anyhow::Result;
 
 use crate::bit_vectors::data::BitVectorData;
-use crate::bit_vectors::BitVector;
 use crate::bit_vectors::NumBits;
+use crate::bit_vectors::RawBitVector;
 use crate::broadword;
 
 const BLOCK_LEN: usize = 8;
@@ -46,8 +46,8 @@ impl Rank9SelIndexBuilder {
         Self::build_rank(data)
     }
 
-    /// Creates a builder from a raw [`BitVector`].
-    pub fn from_raw(bv: &BitVector) -> Self {
+    /// Creates a builder from a raw [`RawBitVector`].
+    pub fn from_raw(bv: &RawBitVector) -> Self {
         let data = BitVectorData::from(bv.clone());
         Self::new(&data)
     }
@@ -183,8 +183,8 @@ impl Rank9SelIndex {
         Rank9SelIndexBuilder::new(data).build()
     }
 
-    /// Creates a new index from a raw [`BitVector`].
-    pub fn from_raw(bv: &BitVector) -> Self {
+    /// Creates a new index from a raw [`RawBitVector`].
+    pub fn from_raw(bv: &RawBitVector) -> Self {
         let data = BitVectorData::from(bv.clone());
         Self::new(&data)
     }
@@ -246,9 +246,9 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{RawBitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndex::from_raw(&bv);
     /// let data = jerky::bit_vectors::BitVectorData::from(bv.clone());
     /// assert_eq!(idx.rank1(&data, 1), Some(1));
@@ -291,9 +291,9 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{RawBitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndex::from_raw(&bv);
     /// let data = jerky::bit_vectors::BitVectorData::from(bv.clone());
     /// assert_eq!(idx.rank0(&data, 1), Some(0));
@@ -325,9 +325,9 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{RawBitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndexBuilder::from_raw(&bv).select1_hints().build();
     /// let data = jerky::bit_vectors::BitVectorData::from(bv.clone());
     /// assert_eq!(idx.select1(&data, 0), Some(0));
@@ -399,9 +399,9 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{RawBitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
-    /// let bv = BitVector::from_bits([true, false, false, true]);
+    /// let bv = RawBitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndexBuilder::from_raw(&bv).select0_hints().build();
     /// let data = jerky::bit_vectors::BitVectorData::from(bv.clone());
     /// assert_eq!(idx.select0(&data, 0), Some(1));
@@ -572,7 +572,7 @@ mod tests {
 
     #[test]
     fn test_zero_copy_from_to_bytes() {
-        let bv = BitVector::from_bits([false, true, true, false, true]);
+        let bv = RawBitVector::from_bits([false, true, true, false, true]);
         let idx = Rank9SelIndexBuilder::from_raw(&bv)
             .select1_hints()
             .select0_hints()

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 
 use anyhow::{anyhow, Result};
 
-use crate::bit_vectors::{Access, BitVector, Build, NumBits, Rank, Rank9Sel, Select};
+use crate::bit_vectors::{Access, Build, NumBits, Rank, Rank9Sel, RawBitVector, Select};
 use crate::int_vectors::CompactVector;
 use crate::utils;
 
@@ -85,7 +85,7 @@ where
         for depth in 0..alph_width {
             let mut next_zeros = CompactVector::new(alph_width).unwrap();
             let mut next_ones = CompactVector::new(alph_width).unwrap();
-            let mut bv = BitVector::new();
+            let mut bv = RawBitVector::new();
             Self::filter(
                 &zeros,
                 alph_width - depth - 1,
@@ -113,7 +113,7 @@ where
         shift: usize,
         next_zeros: &mut CompactVector,
         next_ones: &mut CompactVector,
-        bv: &mut BitVector,
+        bv: &mut RawBitVector,
     ) {
         for val in seq.iter() {
             let bit = ((val >> shift) & 1) == 1;

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -4,7 +4,7 @@
 use anyhow::{anyhow, Result};
 use num_traits::ToPrimitive;
 
-use crate::bit_vectors::BitVector;
+use crate::bit_vectors::RawBitVector;
 use crate::int_vectors::prelude::*;
 use crate::utils;
 
@@ -36,7 +36,7 @@ use crate::utils;
 /// ```
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct CompactVector {
-    chunks: BitVector,
+    chunks: RawBitVector,
     len: usize,
     width: usize,
 }
@@ -69,7 +69,7 @@ impl CompactVector {
             return Err(anyhow!("width must be in 1..=64, but got {width}."));
         }
         Ok(Self {
-            chunks: BitVector::default(),
+            chunks: RawBitVector::default(),
             len: 0,
             width,
         })
@@ -108,7 +108,7 @@ impl CompactVector {
             return Err(anyhow!("width must be in 1..=64, but got {width}."));
         }
         Ok(Self {
-            chunks: BitVector::with_capacity(capa * width),
+            chunks: RawBitVector::with_capacity(capa * width),
             len: 0,
             width,
         })

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 use anyhow::{anyhow, Result};
 use num_traits::ToPrimitive;
 
-use crate::bit_vectors::{self, BitVector, Rank, Rank9Sel};
+use crate::bit_vectors::{self, Rank, Rank9Sel, RawBitVector};
 use crate::int_vectors::{Access, Build, NumVals};
 use crate::utils;
 
@@ -96,7 +96,7 @@ impl DacsByte {
         }
 
         let mut data = vec![vec![]; num_levels];
-        let mut flags = vec![BitVector::default(); num_levels - 1];
+        let mut flags = vec![RawBitVector::default(); num_levels - 1];
 
         for x in vals {
             let mut x = x.to_usize().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,7 @@ pub mod int_vectors;
 mod intrinsics;
 pub mod utils;
 
-pub use bit_vectors::data::{
-    BitVector as IndexedBitVector, BitVectorData, BitVectorIndex, NoIndex,
-};
+pub use bit_vectors::{BitVector, BitVectorData, BitVectorIndex, NoIndex, RawBitVector};
 pub use data::IntVectorData;
 
 // NOTE(kampersanda): We should not use `get()` because it has been already used in most std


### PR DESCRIPTION
## Summary
- rename the mutable bit vector to `RawBitVector`
- re-export the new generic `BitVector<I>` as `BitVector`
- update all modules and benches to the new names
- document the change in the changelog

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686914e0a4f4832296894db00dbc3a7b