### PR TITLE
Add devtest and preflight scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
 - Rename crate from `succdisk` to `jerky`.
 - Replaced the old `BitVector` with the generic `BitVector<I>` and renamed the
   mutable variant to `RawBitVector`.
+- Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and
+  verification workflows.

--- a/scripts/devtest.sh
+++ b/scripts/devtest.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Move to repository root
+cd "$(dirname "$0")/.."
+
+# Run only the tests for quick iteration
+cargo test

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Move to repository root
+cd "$(dirname "$0")/.."
+
+# Ensure required tools are available
+if ! command -v rustfmt >/dev/null 2>&1; then
+  echo "rustfmt not found. Installing via rustup..."
+  rustup component add rustfmt
+fi
+
+if ! cargo kani --version >/dev/null 2>&1; then
+  echo "cargo-kani not found. Installing Kani verifier..."
+  cargo install --locked kani-verifier
+fi
+
+# Run formatting check, tests, and Kani verification
+cargo fmt -- --check
+cargo test
+cargo kani --workspace --exclude jerky-bench


### PR DESCRIPTION
## Summary
- add scripts for quick testing and verification
- run cargo tests and format checks via `preflight.sh`
- document new scripts in `CHANGELOG.md`

## Testing
- `cargo test`
- `scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_686aae98eabc832286267b41b3365f7e