### PR TITLE
Update rustfmt install check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
   mutable variant to `RawBitVector`.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and
   verification workflows.
+- Fixed `scripts/preflight.sh` to install `rustfmt` when `cargo-fmt` is missing.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # Ensure required tools are available
-if ! command -v rustfmt >/dev/null 2>&1; then
-  echo "rustfmt not found. Installing via rustup..."
+if ! command -v cargo-fmt >/dev/null 2>&1; then
+  echo "cargo-fmt not found. Installing via rustup..."
   rustup component add rustfmt
 fi
 


### PR DESCRIPTION
## Summary
- check for `cargo-fmt` in `preflight.sh`
- install `rustfmt` when missing
- document the fix in `CHANGELOG`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ab6d3a538832283b6407cbaf2075e