### PR TITLE
Add push/set bit methods and get_bits for bit vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,7 @@
 - Rename crate from `succdisk` to `jerky`.
 - Replaced the old `BitVector` with the generic `BitVector<I>` and renamed the
   mutable variant to `RawBitVector`.
+- Extended `BitVectorBuilder` with `push_bits` and `set_bit` APIs.
+- Added `get_bits` methods to `BitVectorData` and `BitVector`.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and
   verification workflows.

--- a/src/bit_vectors/data.rs
+++ b/src/bit_vectors/data.rs
@@ -8,7 +8,7 @@
 use crate::bit_vectors::bit_vector::{RawBitVector, WORD_LEN};
 use crate::bit_vectors::{Access, NumBits, Rank, Select};
 use anybytes::{Bytes, View};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 /// Builder that collects raw bits into a zero-copy [`BitVector`].
 #[derive(Debug, Default, Clone)]
@@ -33,6 +33,55 @@ impl BitVectorBuilder {
             *cur |= (bit as usize) << pos_in_word;
         }
         self.len += 1;
+    }
+
+    /// Pushes `len` bits from `bits` at the end.
+    ///
+    /// Bits outside the lowest `len` bits are truncated.
+    pub fn push_bits(&mut self, bits: usize, len: usize) -> Result<()> {
+        if WORD_LEN < len {
+            return Err(anyhow!(
+                "len must be no greater than {WORD_LEN}, but got {len}."
+            ));
+        }
+        if len == 0 {
+            return Ok(());
+        }
+
+        let mask = if len < WORD_LEN {
+            (1 << len) - 1
+        } else {
+            usize::MAX
+        };
+        let bits = bits & mask;
+
+        let pos_in_word = self.len % WORD_LEN;
+        if pos_in_word == 0 {
+            self.words.push(bits);
+        } else {
+            let cur = self.words.last_mut().unwrap();
+            *cur |= bits << pos_in_word;
+            if len > WORD_LEN - pos_in_word {
+                self.words.push(bits >> (WORD_LEN - pos_in_word));
+            }
+        }
+        self.len += len;
+        Ok(())
+    }
+
+    /// Sets the `pos`-th bit to `bit`.
+    pub fn set_bit(&mut self, pos: usize, bit: bool) -> Result<()> {
+        if self.len <= pos {
+            return Err(anyhow!(
+                "pos must be no greater than self.len()={}, but got {pos}.",
+                self.len
+            ));
+        }
+        let word = pos / WORD_LEN;
+        let pos_in_word = pos % WORD_LEN;
+        self.words[word] &= !(1 << pos_in_word);
+        self.words[word] |= (bit as usize) << pos_in_word;
+        Ok(())
     }
 
     /// Extends the builder from an iterator of bits.
@@ -106,6 +155,29 @@ impl BitVectorData {
     /// Returns the number of words stored.
     pub fn num_words(&self) -> usize {
         self.words.len()
+    }
+
+    /// Returns `len` bits starting at position `pos`.
+    pub fn get_bits(&self, pos: usize, len: usize) -> Option<usize> {
+        if WORD_LEN < len || self.len() < pos + len {
+            return None;
+        }
+        if len == 0 {
+            return Some(0);
+        }
+        let block = pos / WORD_LEN;
+        let shift = pos % WORD_LEN;
+        let mask = if len < WORD_LEN {
+            (1 << len) - 1
+        } else {
+            usize::MAX
+        };
+        let bits = if shift + len <= WORD_LEN {
+            (self.words[block] >> shift) & mask
+        } else {
+            (self.words[block] >> shift) | ((self.words[block + 1] << (WORD_LEN - shift)) & mask)
+        };
+        Some(bits)
     }
 
     /// Returns the number of bytes required for the old copy-based serialization.
@@ -280,6 +352,11 @@ impl<I> BitVector<I> {
     pub const fn len(&self) -> usize {
         self.data.len()
     }
+
+    /// Returns the `len` bits starting at `pos`, or [`None`] if out of bounds.
+    pub fn get_bits(&self, pos: usize, len: usize) -> Option<usize> {
+        self.data.get_bits(pos, len)
+    }
 }
 
 impl<I: BitVectorIndex> NumBits for BitVector<I> {
@@ -338,10 +415,12 @@ mod tests {
     #[test]
     fn builder_freeze() {
         let mut builder = BitVectorBuilder::new();
-        builder.extend_bits([true, false, true, false]);
+        builder.extend_bits([true, false]);
+        builder.push_bits(0b10, 2).unwrap();
+        builder.set_bit(1, true).unwrap();
         let bv: BitVector<NoIndex> = builder.freeze::<NoIndex>();
         assert_eq!(bv.len(), 4);
-        assert_eq!(bv.access(2), Some(true));
+        assert_eq!(bv.get_bits(0, 4), Some(0b1011));
     }
 
     #[test]
@@ -354,5 +433,24 @@ mod tests {
         let data = BitVectorData::from_bytes(len, bytes).unwrap();
         let other: BitVector<NoIndex> = data.into();
         assert_eq!(expected, other);
+    }
+
+    #[test]
+    fn get_bits_wrapper() {
+        let data = BitVectorData::from_bits([true, false, true, true, false]);
+        let bv = BitVector::new(data.clone(), NoIndex);
+        assert_eq!(data.get_bits(1, 3), Some(0b110));
+        assert_eq!(data.get_bits(2, 4), None);
+        assert_eq!(bv.get_bits(1, 3), Some(0b110));
+        assert_eq!(bv.get_bits(2, 4), None);
+    }
+
+    #[test]
+    fn builder_push_bits_across_word() {
+        let mut builder = BitVectorBuilder::new();
+        builder.extend_bits(core::iter::repeat(false).take(62));
+        builder.push_bits(0b011111, 6).unwrap();
+        let bv: BitVector<NoIndex> = builder.freeze::<NoIndex>();
+        assert_eq!(bv.data.get_bits(61, 7).unwrap(), 0b0111110);
     }
 }


### PR DESCRIPTION
## Summary
- extend `BitVectorBuilder` with `push_bits` and `set_bit`
- add `get_bits` to `BitVectorData` and `BitVector`
- update unit tests for new APIs

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ab723962c8322b9d3497e7a35fc51