### PR TITLE
Refactor Rank9Sel to use BitVector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Index builders now provide `from_data` constructors operating on `BitVectorData`.
 - Simplified CI workflow to run `scripts/preflight.sh` on pull requests.
 - Fixed `scripts/preflight.sh` to install `rustfmt` when `cargo-fmt` is missing.
+- `Rank9Sel` now stores a `BitVector<Rank9SelIndex>` built via `BitVectorBuilder`.


### PR DESCRIPTION
## Summary
- store BitVector with Rank9SelIndex
- build via BitVectorBuilder and delegate queries to inner BitVector
- update documentation and changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_686abbcbb7b0832297e058a40ce59c5d