### PR TITLE
Add builder freeze for CompactVector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,6 @@
 - `Rank9Sel` now stores a `BitVector<Rank9SelIndex>` built via `BitVectorBuilder`.
 - Added `DArrayFullIndex` wrapping `DArrayIndex<true>` and `DArrayIndex<false>`
   for unified 0/1 select queries.
+- Introduced `CompactVectorBuilder` mutable APIs `push_int`, `set_int`, and `extend`.
+- Added `freeze()` on `CompactVectorBuilder` yielding an immutable `CompactVector` backed by `BitVector<NoIndex>`.
+- `CompactVector::new` and `with_capacity` now return builders; other constructors build via the builder pattern.

--- a/src/int_vectors.rs
+++ b/src/int_vectors.rs
@@ -72,7 +72,7 @@ pub mod dacs_byte;
 
 pub mod prelude;
 
-pub use compact_vector::CompactVector;
+pub use compact_vector::{CompactVector, CompactVectorBuilder};
 pub use dacs_byte::DacsByte;
 
 use anyhow::Result;


### PR DESCRIPTION
## Summary
- support freezing `CompactVectorBuilder` into immutable `CompactVector`
- store frozen vectors in `BitVector<NoIndex>`
- adjust wavelet matrix builder usage and update docs/tests
- document new API in the changelog
- `CompactVector::new` and `with_capacity` now return builders
- document CompactVector builder API thoroughly

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ba50db20083229bdba12d6682c476