### PR TITLE
Use builders for constructing wavelet matrix and DACs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@
 - Introduced `CompactVectorBuilder` mutable APIs `push_int`, `set_int`, and `extend`.
 - Added `freeze()` on `CompactVectorBuilder` yielding an immutable `CompactVector` backed by `BitVector<NoIndex>`.
 - `CompactVector::new` and `with_capacity` now return builders; other constructors build via the builder pattern.
+- Wavelet matrix and DACs builders now use `BitVectorBuilder` for temporary bit
+  vectors, storing only immutable `BitVector` data after construction.


### PR DESCRIPTION
## Summary
- switch `WaveletMatrix` construction to use `BitVectorBuilder`
- build `DacsByte` flag bits with `BitVectorBuilder`
- update changelog

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d01d335a88322a2a38fa8076c422a