### PR TITLE
Remove Build trait from bit vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@
 - Removed obsolete `RawBitVector` type.
 - Removed the `Rank9Sel` wrapper; use `BitVector<Rank9SelIndex>` directly.
 - Removed the `DArray` wrapper; use `BitVector<darray::inner::DArrayFullIndex>` instead.
+- Removed the `Build` trait for bit vectors; construct indexes via `BitVectorBuilder` and `IndexBuilder`.
+- Simplified benchmark code by importing index types and relying on type inference.

--- a/bench/benches/timing_bitvec_rank.rs
+++ b/bench/benches/timing_bitvec_rank.rs
@@ -8,7 +8,8 @@ use criterion::{
 };
 
 use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::Rank;
+use jerky::bit_vectors::rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder};
+use jerky::bit_vectors::{BitVector, NoIndex, Rank};
 
 const SAMPLE_SIZE: usize = 30;
 const WARM_UP_TIME: Duration = Duration::from_secs(5);
@@ -42,16 +43,14 @@ fn perform_bitvec_rank(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], quer
     group.bench_function("jerky/BitVector", |b| {
         let mut builder = BitVectorBuilder::new();
         builder.extend_bits(bits.iter().cloned());
-        let idx: jerky::bit_vectors::BitVector<jerky::bit_vectors::NoIndex> =
-            builder.freeze::<jerky::bit_vectors::NoIndex>();
+        let idx: BitVector<NoIndex> = builder.freeze();
         b.iter(|| run_queries(&idx, &queries));
     });
 
     group.bench_function("jerky/BitVector<Rank9SelIndex>", |b| {
         let mut builder = BitVectorBuilder::new();
         builder.extend_bits(bits.iter().cloned());
-        let idx: jerky::bit_vectors::BitVector<jerky::bit_vectors::rank9sel::inner::Rank9SelIndex> =
-            builder.freeze::<jerky::bit_vectors::rank9sel::inner::Rank9SelIndexBuilder>();
+        let idx = builder.freeze::<Rank9SelIndexBuilder>();
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -1,5 +1,7 @@
+use jerky::bit_vectors::darray::inner::{DArrayFullIndex, DArrayFullIndexBuilder};
 use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::Build;
+use jerky::bit_vectors::rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder};
+use jerky::bit_vectors::BitVector;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
@@ -24,17 +26,15 @@ fn show_memories(p: f64) {
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: jerky::bit_vectors::BitVector<jerky::bit_vectors::rank9sel::inner::Rank9SelIndex> =
-            b.freeze::<jerky::bit_vectors::rank9sel::inner::Rank9SelIndexBuilder>();
+        let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndexBuilder>();
         idx.data.size_in_bytes() + idx.index.size_in_bytes()
     };
     print_memory("BitVector<Rank9SelIndex>", bytes);
 
     let bytes = {
-        let idx = jerky::bit_vectors::BitVector::<
-            jerky::bit_vectors::rank9sel::inner::Rank9SelIndex,
-        >::build_from_bits(bits.iter().cloned(), false, true, true)
-        .unwrap();
+        let mut b = BitVectorBuilder::new();
+        b.extend_bits(bits.iter().cloned());
+        let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndex>();
         idx.data.size_in_bytes() + idx.index.size_in_bytes()
     };
     print_memory("BitVector<Rank9SelIndex> (with select hints)", bytes);
@@ -42,8 +42,7 @@ fn show_memories(p: f64) {
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: jerky::bit_vectors::BitVector<jerky::bit_vectors::darray::inner::DArrayFullIndex> =
-            b.freeze::<jerky::bit_vectors::darray::inner::DArrayFullIndexBuilder>();
+        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndexBuilder>();
         idx.data.size_in_bytes() + idx.index.size_in_bytes()
     };
     print_memory("BitVector<DArrayFullIndex>", bytes);
@@ -51,9 +50,8 @@ fn show_memories(p: f64) {
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: jerky::bit_vectors::BitVector<jerky::bit_vectors::darray::inner::DArrayFullIndex> =
-            b.freeze::<jerky::bit_vectors::darray::inner::DArrayFullIndexBuilder>();
-        let r9 = jerky::bit_vectors::rank9sel::inner::Rank9SelIndex::new(&idx.data);
+        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndexBuilder>();
+        let r9 = Rank9SelIndex::new(&idx.data);
         idx.data.size_in_bytes() + idx.index.size_in_bytes() + r9.size_in_bytes()
     };
     print_memory("BitVector<DArrayFullIndex> (with rank index)", bytes);

--- a/bench/src/mem_chrseq.rs
+++ b/bench/src/mem_chrseq.rs
@@ -1,5 +1,7 @@
 use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::Rank;
+use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
+use jerky::bit_vectors::{BitVector, NoIndex, Rank};
+use jerky::char_sequences::WaveletMatrix;
 use jerky::int_vectors::CompactVector;
 
 const DBLP_PSEF_STR: &str = include_str!("../data/texts/dblp.1MiB.txt");
@@ -20,8 +22,7 @@ fn load_text(s: &str) -> CompactVector {
     for &c in &text {
         builder.set_bit(c as usize, true).unwrap();
     }
-    let alphabet: jerky::bit_vectors::BitVector<jerky::bit_vectors::NoIndex> =
-        builder.freeze::<jerky::bit_vectors::NoIndex>();
+    let alphabet: BitVector<NoIndex> = builder.freeze();
     for i in 0..text.len() {
         text[i] = alphabet.rank1(text[i] as usize).unwrap() as u8;
     }
@@ -33,13 +34,10 @@ fn show_memories(title: &str, text: &CompactVector) {
     show_data_stats(text);
 
     let bytes = {
-        let idx = jerky::char_sequences::WaveletMatrix::<
-            jerky::bit_vectors::BitVector<jerky::bit_vectors::rank9sel::inner::Rank9SelIndex>,
-        >::new(text.clone())
-        .unwrap();
+        let idx = WaveletMatrix::<Rank9SelIndex>::new(text.clone()).unwrap();
         idx.size_in_bytes()
     };
-    print_memory("WaveletMatrix<BitVector<Rank9SelIndex>>", bytes, text.len());
+    print_memory("WaveletMatrix<Rank9SelIndex>", bytes, text.len());
 }
 
 fn show_data_stats(text: &CompactVector) {

--- a/src/bit_vectors.rs
+++ b/src/bit_vectors.rs
@@ -54,14 +54,11 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use jerky::bit_vectors::{rank9sel::inner::Rank9SelIndex, BitVector, prelude::*};
+//! use jerky::bit_vectors::{data::BitVectorBuilder, rank9sel::inner::Rank9SelIndex, BitVector, prelude::*};
 //!
-//! let bv: BitVector<Rank9SelIndex> = BitVector::build_from_bits(
-//!     [true, false, false, true],
-//!     true, // Enables rank1/0
-//!     true, // Enables select1
-//!     true  // Enables select0
-//! )?;
+//! let mut builder = BitVectorBuilder::new();
+//! builder.extend_bits([true, false, false, true]);
+//! let bv = builder.freeze::<Rank9SelIndex>();
 //!
 //! assert_eq!(bv.num_bits(), 4);
 //! assert_eq!(bv.num_ones(), 2);
@@ -84,35 +81,7 @@ pub mod rank9sel;
 
 pub use data::{BitVector, BitVectorData, BitVectorIndex, IndexBuilder, NoIndex};
 
-use anyhow::Result;
-
 /// Interface for building a bit vector with rank/select queries.
-pub trait Build {
-    /// Creates a new vector from input bit stream `bits`.
-    ///
-    /// A data structure may not support a part of rank/select queries in the default
-    /// configuration. The last three flags allow to enable them if optionally supported.
-    ///
-    /// # Arguments
-    ///
-    /// - `bits`: Bit stream.
-    /// - `with_rank`: Flag to enable rank1/0.
-    /// - `with_select1`: Flag to enable select1.
-    /// - `with_select0`: Flag to enable select0.
-    ///
-    /// # Errors
-    ///
-    /// An error is returned if specified queries are not supported.
-    fn build_from_bits<I>(
-        bits: I,
-        with_rank: bool,
-        with_select1: bool,
-        with_select0: bool,
-    ) -> Result<Self>
-    where
-        I: IntoIterator<Item = bool>,
-        Self: Sized;
-}
 
 /// Interface for reporting basic statistics in a bit vector.
 pub trait NumBits {

--- a/src/bit_vectors/darray/inner.rs
+++ b/src/bit_vectors/darray/inner.rs
@@ -6,7 +6,7 @@ use anybytes::{Bytes, View};
 use anyhow::Result;
 
 use crate::bit_vectors::data::BitVectorData;
-use crate::bit_vectors::{Access, NumBits};
+use crate::bit_vectors::Access;
 use crate::broadword;
 
 const BLOCK_LEN: usize = 1024;
@@ -20,6 +20,14 @@ pub struct DArrayIndex<const OVER_ONE: bool> {
     subblock_inventory: View<[u16]>,
     overflow_positions: View<[usize]>,
     num_positions: usize,
+}
+
+impl<const OVER_ONE: bool> crate::bit_vectors::data::IndexBuilder for DArrayIndex<OVER_ONE> {
+    type Built = DArrayIndex<OVER_ONE>;
+
+    fn build(data: &BitVectorData) -> Self::Built {
+        DArrayIndex::new(data)
+    }
 }
 
 /// Builder for [`DArrayIndex`].
@@ -51,6 +59,14 @@ impl<const OVER_ONE: bool> Default for DArrayIndex<OVER_ONE> {
 pub struct DArrayFullIndex {
     s1: DArrayIndex<true>,
     s0: DArrayIndex<false>,
+}
+
+impl crate::bit_vectors::data::IndexBuilder for DArrayFullIndex {
+    type Built = DArrayFullIndex;
+
+    fn build(data: &BitVectorData) -> Self::Built {
+        DArrayFullIndex::new(data)
+    }
 }
 
 /// Builder for [`DArrayFullIndex`].

--- a/src/bit_vectors/prelude.rs
+++ b/src/bit_vectors/prelude.rs
@@ -6,4 +6,4 @@
 //! # #![allow(unused_imports)]
 //! use jerky::bit_vectors::prelude::*;
 //! ```
-pub use crate::bit_vectors::{Access, Build, NumBits, Rank, Select};
+pub use crate::bit_vectors::{Access, NumBits, Rank, Select};

--- a/src/bit_vectors/rank9sel/inner.rs
+++ b/src/bit_vectors/rank9sel/inner.rs
@@ -6,7 +6,6 @@ use anybytes::{Bytes, View};
 use anyhow::Result;
 
 use crate::bit_vectors::data::BitVectorData;
-use crate::bit_vectors::NumBits;
 use crate::broadword;
 
 const BLOCK_LEN: usize = 8;

--- a/src/bit_vectors/rank9sel/mod.rs
+++ b/src/bit_vectors/rank9sel/mod.rs
@@ -1,34 +1,16 @@
 //! Rank9/Select index implementation.
 pub mod inner;
 
-use anyhow::Result;
-
-use crate::bit_vectors::data::{BitVector, BitVectorBuilder};
-use crate::bit_vectors::{Build, NoIndex};
+use crate::bit_vectors::data::{BitVectorData, IndexBuilder};
 use inner::{Rank9SelIndex, Rank9SelIndexBuilder};
 
-impl Build for BitVector<Rank9SelIndex> {
-    fn build_from_bits<I>(
-        bits: I,
-        _with_rank: bool,
-        with_select1: bool,
-        with_select0: bool,
-    ) -> Result<Self>
-    where
-        I: IntoIterator<Item = bool>,
-        Self: Sized,
-    {
-        let mut bvb = BitVectorBuilder::new();
-        bvb.extend_bits(bits);
-        let BitVector { data, .. }: BitVector<NoIndex> = bvb.freeze::<NoIndex>();
-        let mut builder = Rank9SelIndexBuilder::from_data(&data);
-        if with_select1 {
-            builder = builder.select1_hints();
-        }
-        if with_select0 {
-            builder = builder.select0_hints();
-        }
-        let rs = builder.build();
-        Ok(BitVector::new(data, rs))
+impl IndexBuilder for Rank9SelIndex {
+    type Built = Rank9SelIndex;
+
+    fn build(data: &BitVectorData) -> Self::Built {
+        Rank9SelIndexBuilder::from_data(data)
+            .select1_hints()
+            .select0_hints()
+            .build()
     }
 }

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -312,10 +312,10 @@ mod tests {
 
         let mut b = BitVectorBuilder::new();
         b.extend_bits([true, false, false, true, false]);
-        let f0: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndexBuilder>();
+        let f0 = b.freeze::<Rank9SelIndexBuilder>();
         let mut b = BitVectorBuilder::new();
         b.extend_bits([false, true]);
-        let f1: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndexBuilder>();
+        let f1 = b.freeze::<Rank9SelIndexBuilder>();
         assert_eq!(seq.flags, vec![f0, f1]);
 
         assert!(!seq.is_empty());


### PR DESCRIPTION
## Summary
- drop the `Build` trait and related imports
- implement `IndexBuilder` for bit-vector indexes
- update `WaveletMatrix` to be generic over the index type
- adjust benches and docs for the new API
- note removal in `CHANGELOG`
- simplify benchmark code by importing index types and relying on type inference

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6870f3aa1f4c83229d837b08817f2749