### PR TITLE
Remove IndexBuilder in favor of generic build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,4 +26,5 @@
 - Removed the `Rank9Sel` wrapper; use `BitVector<Rank9SelIndex>` directly.
 - Removed the `DArray` wrapper; use `BitVector<darray::inner::DArrayFullIndex>` instead.
 - Removed the `Build` trait for bit vectors; construct indexes via `BitVectorBuilder` and `IndexBuilder`.
+- Removed index builders in favor of parameterized index types constructed with `build`.
 - Simplified benchmark code by importing index types and relying on type inference.

--- a/bench/benches/timing_bitvec_rank.rs
+++ b/bench/benches/timing_bitvec_rank.rs
@@ -8,7 +8,7 @@ use criterion::{
 };
 
 use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder};
+use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use jerky::bit_vectors::{BitVector, NoIndex, Rank};
 
 const SAMPLE_SIZE: usize = 30;
@@ -50,7 +50,7 @@ fn perform_bitvec_rank(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], quer
     group.bench_function("jerky/BitVector<Rank9SelIndex>", |b| {
         let mut builder = BitVectorBuilder::new();
         builder.extend_bits(bits.iter().cloned());
-        let idx = builder.freeze::<Rank9SelIndexBuilder>();
+        let idx = builder.freeze::<Rank9SelIndex>();
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/benches/timing_bitvec_select.rs
+++ b/bench/benches/timing_bitvec_select.rs
@@ -6,7 +6,7 @@ use rand_chacha::ChaChaRng;
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
-use jerky::bit_vectors::darray::inner::{DArrayFullIndex, DArrayFullIndexBuilder};
+use jerky::bit_vectors::darray::inner::DArrayFullIndex;
 use jerky::bit_vectors::data::BitVectorBuilder;
 use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use jerky::bit_vectors::{BitVector, NoIndex, Select};

--- a/bench/benches/timing_chrseq_access.rs
+++ b/bench/benches/timing_chrseq_access.rs
@@ -81,7 +81,7 @@ fn criterion_chrseq_access_proteins(c: &mut Criterion) {
 
 fn run_queries<I>(idx: &WaveletMatrix<I>, queries: &[usize])
 where
-    I: BitVectorIndex + IndexBuilder<Built = I>,
+    I: BitVectorIndex,
 {
     let mut sum = 0;
     for &q in queries {

--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -1,6 +1,6 @@
-use jerky::bit_vectors::darray::inner::{DArrayFullIndex, DArrayFullIndexBuilder};
+use jerky::bit_vectors::darray::inner::DArrayFullIndex;
 use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder};
+use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use jerky::bit_vectors::BitVector;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
@@ -26,7 +26,7 @@ fn show_memories(p: f64) {
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndexBuilder>();
+        let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndex>();
         idx.data.size_in_bytes() + idx.index.size_in_bytes()
     };
     print_memory("BitVector<Rank9SelIndex>", bytes);
@@ -42,7 +42,7 @@ fn show_memories(p: f64) {
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndexBuilder>();
+        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndex>();
         idx.data.size_in_bytes() + idx.index.size_in_bytes()
     };
     print_memory("BitVector<DArrayFullIndex>", bytes);
@@ -50,7 +50,7 @@ fn show_memories(p: f64) {
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndexBuilder>();
+        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndex>();
         let r9 = Rank9SelIndex::new(&idx.data);
         idx.data.size_in_bytes() + idx.index.size_in_bytes() + r9.size_in_bytes()
     };

--- a/src/bit_vectors.rs
+++ b/src/bit_vectors.rs
@@ -79,7 +79,7 @@ pub mod data;
 pub mod prelude;
 pub mod rank9sel;
 
-pub use data::{BitVector, BitVectorData, BitVectorIndex, IndexBuilder, NoIndex};
+pub use data::{BitVector, BitVectorData, BitVectorIndex, NoIndex};
 
 /// Interface for building a bit vector with rank/select queries.
 

--- a/src/bit_vectors/darray/inner.rs
+++ b/src/bit_vectors/darray/inner.rs
@@ -22,29 +22,13 @@ pub struct DArrayIndex<const OVER_ONE: bool> {
     num_positions: usize,
 }
 
-impl<const OVER_ONE: bool> crate::bit_vectors::data::IndexBuilder for DArrayIndex<OVER_ONE> {
-    type Built = DArrayIndex<OVER_ONE>;
-
-    fn build(data: &BitVectorData) -> Self::Built {
-        DArrayIndex::new(data)
-    }
-}
-
 /// Builder for [`DArrayIndex`].
 #[derive(Default, Debug, Clone)]
-pub struct DArrayIndexBuilder<const OVER_ONE: bool> {
+struct DArrayIndexBuilder<const OVER_ONE: bool> {
     block_inventory: Vec<isize>,
     subblock_inventory: Vec<u16>,
     overflow_positions: Vec<usize>,
     num_positions: usize,
-}
-
-impl<const OVER_ONE: bool> crate::bit_vectors::data::IndexBuilder for DArrayIndexBuilder<OVER_ONE> {
-    type Built = DArrayIndex<OVER_ONE>;
-
-    fn build(data: &BitVectorData) -> Self::Built {
-        DArrayIndexBuilder::<OVER_ONE>::new(data).build()
-    }
 }
 
 impl<const OVER_ONE: bool> Default for DArrayIndex<OVER_ONE> {
@@ -61,27 +45,11 @@ pub struct DArrayFullIndex {
     s0: DArrayIndex<false>,
 }
 
-impl crate::bit_vectors::data::IndexBuilder for DArrayFullIndex {
-    type Built = DArrayFullIndex;
-
-    fn build(data: &BitVectorData) -> Self::Built {
-        DArrayFullIndex::new(data)
-    }
-}
-
 /// Builder for [`DArrayFullIndex`].
 #[derive(Default, Debug, Clone)]
-pub struct DArrayFullIndexBuilder {
+struct DArrayFullIndexBuilder {
     s1: DArrayIndexBuilder<true>,
     s0: DArrayIndexBuilder<false>,
-}
-
-impl crate::bit_vectors::data::IndexBuilder for DArrayFullIndexBuilder {
-    type Built = DArrayFullIndex;
-
-    fn build(data: &BitVectorData) -> Self::Built {
-        DArrayFullIndexBuilder::new(data).build()
-    }
 }
 
 impl Default for DArrayFullIndex {
@@ -132,6 +100,10 @@ impl DArrayFullIndex {
 }
 
 impl crate::bit_vectors::data::BitVectorIndex for DArrayFullIndex {
+    fn build(data: &BitVectorData) -> Self {
+        DArrayFullIndex::new(data)
+    }
+
     fn num_ones(&self, _data: &BitVectorData) -> usize {
         self.num_ones()
     }
@@ -439,6 +411,9 @@ impl<const OVER_ONE: bool> DArrayIndex<OVER_ONE> {
 }
 
 impl<const OVER_ONE: bool> crate::bit_vectors::data::BitVectorIndex for DArrayIndex<OVER_ONE> {
+    fn build(data: &BitVectorData) -> Self {
+        DArrayIndex::new(data)
+    }
     fn num_ones(&self, _data: &BitVectorData) -> usize {
         self.num_ones()
     }
@@ -521,17 +496,16 @@ mod tests {
     #[test]
     fn test_builder_roundtrip() {
         let data = BitVectorData::from_bits([true, false, true, true, false, false]);
-        let builder = DArrayIndexBuilder::<true>::from_data(&data);
-        let idx = builder.clone().build();
-        let bytes = builder.build().to_bytes();
-        let from = DArrayIndex::from_bytes(bytes).unwrap();
+        let idx = DArrayIndex::<true>::new(&data);
+        let bytes = idx.to_bytes();
+        let from = DArrayIndex::<true>::from_bytes(bytes).unwrap();
         assert_eq!(idx, from);
     }
 
     #[test]
     fn test_builder_from_data() {
         let data = BitVectorData::from_bits([true, false, false, true]);
-        let idx_from_data = DArrayIndexBuilder::<true>::from_data(&data).build();
+        let idx_from_data = DArrayIndex::<true>::new(&data);
         let idx_from_new = DArrayIndex::<true>::new(&data);
         assert_eq!(idx_from_data, idx_from_new);
     }

--- a/src/bit_vectors/darray/mod.rs
+++ b/src/bit_vectors/darray/mod.rs
@@ -2,4 +2,4 @@
 
 pub mod inner;
 
-pub use inner::{DArrayFullIndex, DArrayFullIndexBuilder, DArrayIndex, DArrayIndexBuilder};
+pub use inner::{DArrayFullIndex, DArrayIndex};

--- a/src/bit_vectors/rank9sel/mod.rs
+++ b/src/bit_vectors/rank9sel/mod.rs
@@ -1,16 +1,4 @@
 //! Rank9/Select index implementation.
 pub mod inner;
 
-use crate::bit_vectors::data::{BitVectorData, IndexBuilder};
-use inner::{Rank9SelIndex, Rank9SelIndexBuilder};
-
-impl IndexBuilder for Rank9SelIndex {
-    type Built = Rank9SelIndex;
-
-    fn build(data: &BitVectorData) -> Self::Built {
-        Rank9SelIndexBuilder::from_data(data)
-            .select1_hints()
-            .select0_hints()
-            .build()
-    }
-}
+pub use inner::Rank9SelIndex;

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 
 use anyhow::{anyhow, Result};
 
-use crate::bit_vectors::data::{BitVectorBuilder, BitVectorIndex, IndexBuilder};
+use crate::bit_vectors::data::{BitVectorBuilder, BitVectorIndex};
 use crate::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use crate::bit_vectors::{Access, BitVector, NumBits, Rank, Select};
 use crate::int_vectors::{CompactVector, CompactVectorBuilder};
@@ -62,7 +62,7 @@ pub struct WaveletMatrix<I> {
 
 impl<I> WaveletMatrix<I>
 where
-    I: BitVectorIndex + IndexBuilder<Built = I>,
+    I: BitVectorIndex,
 {
     /// Creates a new instance from an input sequence `seq`.
     ///
@@ -578,7 +578,7 @@ impl<'a, I> Iter<'a, I> {
 
 impl<I> Iterator for Iter<'_, I>
 where
-    I: BitVectorIndex + IndexBuilder<Built = I>,
+    I: BitVectorIndex,
 {
     type Item = usize;
 

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use num_traits::ToPrimitive;
 
 use crate::bit_vectors::data::BitVectorBuilder;
-use crate::bit_vectors::rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder};
+use crate::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use crate::bit_vectors::{self, BitVector, Rank};
 use crate::int_vectors::{Access, Build, NumVals};
 use crate::utils;
@@ -118,7 +118,7 @@ impl DacsByte {
 
         let flags = flags
             .into_iter()
-            .map(|bvb| bvb.freeze::<Rank9SelIndexBuilder>())
+            .map(|bvb| bvb.freeze::<Rank9SelIndex<true, true>>())
             .collect();
         Ok(Self { data, flags })
     }
@@ -312,10 +312,10 @@ mod tests {
 
         let mut b = BitVectorBuilder::new();
         b.extend_bits([true, false, false, true, false]);
-        let f0 = b.freeze::<Rank9SelIndexBuilder>();
+        let f0 = b.freeze::<Rank9SelIndex<true, true>>();
         let mut b = BitVectorBuilder::new();
         b.extend_bits([false, true]);
-        let f1 = b.freeze::<Rank9SelIndexBuilder>();
+        let f1 = b.freeze::<Rank9SelIndex<true, true>>();
         assert_eq!(seq.flags, vec![f0, f1]);
 
         assert!(!seq.is_empty());


### PR DESCRIPTION
## Summary
- remove the `IndexBuilder` trait and update `BitVectorBuilder::freeze`
- implement `build` as part of `BitVectorIndex`
- parameterize `Rank9SelIndex` and internal builders with const generics
- update darray index and benchmarks to use the new API
- adjust documentation and tests

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873bf78bbc48322830d08c8a23b8f4e