### PR TITLE
Refactor DArray index generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 - Simplified CI workflow to run `scripts/preflight.sh` on pull requests.
 - Fixed `scripts/preflight.sh` to install `rustfmt` when `cargo-fmt` is missing.
 - `Rank9Sel` now stores a `BitVector<Rank9SelIndex>` built via `BitVectorBuilder`.
-- Added `DArrayFullIndex` wrapping `DArrayIndex<true>` and `DArrayIndex<false>`
-  for unified 0/1 select queries.
+- Replaced `DArrayFullIndex` with new `DArrayIndex` that uses const generics
+  to optionally include `select1` and `select0` support.
 - Introduced `CompactVectorBuilder` mutable APIs `push_int`, `set_int`, and `extend`.
 - Added `freeze()` on `CompactVectorBuilder` yielding an immutable `CompactVector` backed by `BitVector<NoIndex>`.
 - `CompactVector::new` and `with_capacity` now return builders; other constructors build via the builder pattern.
@@ -24,7 +24,7 @@
   vectors, storing only immutable `BitVector` data after construction.
 - Removed obsolete `RawBitVector` type.
 - Removed the `Rank9Sel` wrapper; use `BitVector<Rank9SelIndex>` directly.
-- Removed the `DArray` wrapper; use `BitVector<darray::inner::DArrayFullIndex>` instead.
+- Removed the `DArray` wrapper; use `BitVector<darray::inner::DArrayIndex>` instead.
 - Removed the `Build` trait for bit vectors; construct indexes via `BitVectorBuilder` and `IndexBuilder`.
 - Removed index builders in favor of parameterized index types constructed with `build`.
 - Simplified benchmark code by importing index types and relying on type inference.

--- a/bench/benches/timing_bitvec_select.rs
+++ b/bench/benches/timing_bitvec_select.rs
@@ -6,7 +6,7 @@ use rand_chacha::ChaChaRng;
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
-use jerky::bit_vectors::darray::inner::DArrayFullIndex;
+use jerky::bit_vectors::darray::inner::DArrayIndex;
 use jerky::bit_vectors::data::BitVectorBuilder;
 use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use jerky::bit_vectors::{BitVector, NoIndex, Select};
@@ -58,10 +58,10 @@ fn perform_bitvec_select(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], qu
         b.iter(|| run_queries(&idx, &queries));
     });
 
-    group.bench_function("jerky/BitVector<DArrayFullIndex>", |b| {
+    group.bench_function("jerky/BitVector<DArrayIndex>", |b| {
         let mut builder = BitVectorBuilder::new();
         builder.extend_bits(bits.iter().cloned());
-        let idx = builder.freeze::<DArrayFullIndex>();
+        let idx = builder.freeze::<DArrayIndex>();
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/benches/timing_chrseq_access.rs
+++ b/bench/benches/timing_chrseq_access.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
-use jerky::bit_vectors::darray::inner::DArrayFullIndex;
+use jerky::bit_vectors::darray::inner::DArrayIndex;
 use jerky::bit_vectors::data::BitVectorBuilder;
 use jerky::bit_vectors::prelude::*;
 use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
@@ -100,8 +100,8 @@ fn perform_chrseq_access(group: &mut BenchmarkGroup<WallTime>, text: &CompactVec
         b.iter(|| run_queries(&idx, &queries));
     });
 
-    group.bench_function("jerky/WaveletMatrix<DArrayFullIndex>", |b| {
-        let idx = WaveletMatrix::<DArrayFullIndex>::new(text.clone()).unwrap();
+    group.bench_function("jerky/WaveletMatrix<DArrayIndex>", |b| {
+        let idx = WaveletMatrix::<DArrayIndex>::new(text.clone()).unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -1,4 +1,4 @@
-use jerky::bit_vectors::darray::inner::DArrayFullIndex;
+use jerky::bit_vectors::darray::inner::DArrayIndex;
 use jerky::bit_vectors::data::BitVectorBuilder;
 use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use jerky::bit_vectors::BitVector;
@@ -42,19 +42,19 @@ fn show_memories(p: f64) {
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndex>();
+        let idx: BitVector<DArrayIndex> = b.freeze::<DArrayIndex>();
         idx.data.size_in_bytes() + idx.index.size_in_bytes()
     };
-    print_memory("BitVector<DArrayFullIndex>", bytes);
+    print_memory("BitVector<DArrayIndex>", bytes);
 
     let bytes = {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
-        let idx: BitVector<DArrayFullIndex> = b.freeze::<DArrayFullIndex>();
+        let idx: BitVector<DArrayIndex> = b.freeze::<DArrayIndex>();
         let r9 = Rank9SelIndex::new(&idx.data);
         idx.data.size_in_bytes() + idx.index.size_in_bytes() + r9.size_in_bytes()
     };
-    print_memory("BitVector<DArrayFullIndex> (with rank index)", bytes);
+    print_memory("BitVector<DArrayIndex> (with rank index)", bytes);
 }
 
 fn print_memory(name: &str, bytes: usize) {

--- a/src/bit_vectors.rs
+++ b/src/bit_vectors.rs
@@ -24,7 +24,7 @@
 //! | --- | :-: | :-: | :-: | :-: | :-: |
 //! | [`BitVector`] | $`O(1)`$  | $`O(u)`$ | $`O(u)`$ | $`O(1)`$ | $`u`$ |
 //! | [`BitVector<rank9sel::inner::Rank9SelIndex>`] | $`O(1)`$ | $`O(1)`$ | $`O(\lg u)`$ | -- | $`u + o(u)`$ |
-//! | [`BitVector<darray::inner::DArrayFullIndex>`] | $`O(1)`$ | $`O(1)`$ | $`O(1)`$ | -- | $`u + o(u)`$ |
+//! | [`BitVector<darray::inner::DArrayIndex>`] | $`O(1)`$ | $`O(1)`$ | $`O(1)`$ | -- | $`u + o(u)`$ |
 //!
 //! ## Plain bit vectors without index
 //!
@@ -35,12 +35,12 @@
 //!
 //! ## Plain bit vectors with index
 //!
-//! [`BitVector<rank9sel::inner::Rank9SelIndex>`] and [`BitVector<darray::inner::DArrayFullIndex>`] are index structures for faster queries built on [`BitVector`].
+//! [`BitVector<rank9sel::inner::Rank9SelIndex>`] and [`BitVector<darray::inner::DArrayIndex>`] are index structures for faster queries built on [`BitVector`].
 //!
 //! [`BitVector<rank9sel::inner::Rank9SelIndex>`] is an implementation of Vigna's Rank9 and hinted selection techniques, supporting
 //! constant-time Rank and logarithmic-time Select queries.
 //!
-//! [`BitVector<darray::inner::DArrayFullIndex>`] implements the dense array technique of Okanohara and Sadakane.
+//! [`BitVector<darray::inner::DArrayIndex>`] implements the dense array technique of Okanohara and Sadakane.
 //! If you need only Select queries on dense sets (i.e., $`n/u \approx 0.5`$), this will be the most candidate.
 //! Rank/Predecessor/Successor queries are optionally enabled using the [`Rank9SelIndex`](rank9sel::inner::Rank9SelIndex) index.
 //! This structure outperforms [`BitVector<rank9sel::inner::Rank9SelIndex>`] in complexity, but the practical space overhead can be larger.

--- a/src/bit_vectors/darray/mod.rs
+++ b/src/bit_vectors/darray/mod.rs
@@ -2,4 +2,4 @@
 
 pub mod inner;
 
-pub use inner::{DArrayFullIndex, DArrayIndex};
+pub use inner::DArrayIndex;


### PR DESCRIPTION
## Summary
- unify DArray with Rank9Sel style const generic configuration
- rename old single-index implementation to `DArraySelectIndex`
- introduce `DArrayIndex` with optional select1/select0 support
- adjust benchmarks and docs
- update changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6874d958cdf483228c28743fd6f20cce