### PR TITLE
Remove completed section from inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,18 @@ The project balances a few key goals:
 * Avoid small cosmetic changes that blow up the diff unless explicitly requested.
 * Use clear commit messages describing the change.
 * Add an entry to `CHANGELOG.md` summarizing your task.
+* Record new tasks and ideas in `INVENTORY.md` for later discussion.
 
 ## Pull Request Notes
 
 When opening a PR, include a short summary of what changed and reference relevant file sections.
+
+## Inventory
+
+Record future work and ideas in `INVENTORY.md`. Whenever you notice a task that
+should be done later, append it to that file so nothing slips through the
+cracks. Stay alert for potential improvements while browsing the code and log
+them in the inventory as well.
 
 ## Working With Codex (the Assistant)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@
 - Removed the `Build` trait for bit vectors; construct indexes via `BitVectorBuilder` and `IndexBuilder`.
 - Removed index builders in favor of parameterized index types constructed with `build`.
 - Simplified benchmark code by importing index types and relying on type inference.
+- Added `INVENTORY.md` for tracking pending work and ideas.
+- Clarified inventory instructions in `AGENTS.md`.
+- Removed the `## Completed Work` section from `INVENTORY.md`.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1,0 +1,13 @@
+# Inventory
+
+## Potential Removals
+- None at the moment.
+
+## Desired Functionality
+- Implement caching optimizations for `WaveletMatrix` iterator.
+- Expose utilities for inspecting and debugging built vectors.
+- Provide more usage examples and documentation.
+- Evaluate additional succinct data structures to include.
+
+## Discovered Issues
+- `katex.html` performs manual string replacements; consider DOM-based manipulation.


### PR DESCRIPTION
## Summary
- remove the `## Completed Work` section from `INVENTORY.md`
- note the change in `CHANGELOG.md`

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68759bf22b1c8322909cb232aca112a5