### PR TITLE
Remove unused from_data builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and
   verification workflows.
-- Index builders now provide `from_data` constructors operating on `BitVectorData`.
 - Simplified CI workflow to run `scripts/preflight.sh` on pull requests.
 - Fixed `scripts/preflight.sh` to install `rustfmt` when `cargo-fmt` is missing.
 - `Rank9Sel` now stores a `BitVector<Rank9SelIndex>` built via `BitVectorBuilder`.

--- a/src/bit_vectors/rank9sel/inner.rs
+++ b/src/bit_vectors/rank9sel/inner.rs
@@ -36,11 +36,6 @@ impl<const SELECT1: bool, const SELECT0: bool> Rank9SelIndexBuilder<SELECT1, SEL
         Self::build_rank(data)
     }
 
-    /// Creates a builder from the given [`BitVectorData`].
-    pub fn from_data(data: &BitVectorData) -> Self {
-        Self::new(data)
-    }
-
     /// Builds an index for faster `select1` queries.
     pub fn select1_hints(self) -> Self {
         self.build_select1()
@@ -585,10 +580,10 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_from_data() {
+    fn test_builder_new_equivalence() {
         let data = BitVectorData::from_bits([true, false, true, false]);
-        let idx_from_data = Rank9SelIndex::<true, true>::new(&data);
-        let idx_from_new = Rank9SelIndex::<true, true>::new(&data);
-        assert_eq!(idx_from_data, idx_from_new);
+        let idx1 = Rank9SelIndex::<true, true>::new(&data);
+        let idx2 = Rank9SelIndex::<true, true>::new(&data);
+        assert_eq!(idx1, idx2);
     }
 }


### PR DESCRIPTION
## Summary
- delete `Rank9SelIndexBuilder::from_data`
- rename test accordingly
- drop related CHANGELOG entry

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6877a18281688322a455f76f873632ab