### PR TITLE
Update bench imports for bit_vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@
 - Unified bit vector implementation under `bit_vector.rs` and removed the
   redundant `data` module.
 - Renamed the `bit_vectors` module to `bit_vector` and updated imports.
+- Updated benchmarks to use `jerky::bit_vector` imports.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -14,3 +14,4 @@
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
+- Benchmarks still used the old `jerky::bit_vectors` path, breaking compilation.

--- a/bench/benches/timing_bitvec_rank.rs
+++ b/bench/benches/timing_bitvec_rank.rs
@@ -7,9 +7,9 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
 
-use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
-use jerky::bit_vectors::{BitVector, NoIndex, Rank};
+use jerky::bit_vector::bit_vector::BitVectorBuilder;
+use jerky::bit_vector::rank9sel::inner::Rank9SelIndex;
+use jerky::bit_vector::{BitVector, NoIndex, Rank};
 
 const SAMPLE_SIZE: usize = 30;
 const WARM_UP_TIME: Duration = Duration::from_secs(5);

--- a/bench/benches/timing_bitvec_select.rs
+++ b/bench/benches/timing_bitvec_select.rs
@@ -6,9 +6,9 @@ use rand_chacha::ChaChaRng;
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
-use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
-use jerky::bit_vectors::{BitVector, NoIndex, Select};
+use jerky::bit_vector::bit_vector::BitVectorBuilder;
+use jerky::bit_vector::rank9sel::inner::Rank9SelIndex;
+use jerky::bit_vector::{BitVector, NoIndex, Select};
 
 const SAMPLE_SIZE: usize = 30;
 const WARM_UP_TIME: Duration = Duration::from_secs(5);

--- a/bench/benches/timing_chrseq_access.rs
+++ b/bench/benches/timing_chrseq_access.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
-use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::prelude::*;
-use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
-use jerky::bit_vectors::{BitVector, NoIndex};
+use jerky::bit_vector::bit_vector::BitVectorBuilder;
+use jerky::bit_vector::prelude::*;
+use jerky::bit_vector::rank9sel::inner::Rank9SelIndex;
+use jerky::bit_vector::{BitVector, NoIndex};
 use jerky::char_sequences::WaveletMatrix;
 use jerky::int_vectors::CompactVector;
 

--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -1,6 +1,6 @@
-use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
-use jerky::bit_vectors::BitVector;
+use jerky::bit_vector::bit_vector::BitVectorBuilder;
+use jerky::bit_vector::rank9sel::inner::Rank9SelIndex;
+use jerky::bit_vector::BitVector;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 

--- a/bench/src/mem_chrseq.rs
+++ b/bench/src/mem_chrseq.rs
@@ -1,6 +1,6 @@
-use jerky::bit_vectors::data::BitVectorBuilder;
-use jerky::bit_vectors::rank9sel::inner::Rank9SelIndex;
-use jerky::bit_vectors::{BitVector, NoIndex, Rank};
+use jerky::bit_vector::bit_vector::BitVectorBuilder;
+use jerky::bit_vector::rank9sel::inner::Rank9SelIndex;
+use jerky::bit_vector::{BitVector, NoIndex, Rank};
 use jerky::char_sequences::WaveletMatrix;
 use jerky::int_vectors::CompactVector;
 


### PR DESCRIPTION
## Summary
- fix outdated benchmark imports from `jerky::bit_vectors`
- update CHANGELOG and INVENTORY for benchmark import fix

## Testing
- `cargo check` in bench crate
- `cargo test` in bench crate
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877cc3786708322a17efa2a1a3758b8