### PR TITLE
Use View in DacsByte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Replaced the old `BitVector` with the generic `BitVector<I>` and renamed the
   mutable variant to `RawBitVector`.
 - Extended `BitVectorBuilder` with `push_bits` and `set_bit` APIs.
+- `DacsByte` now stores level data as zero-copy `View<[u8]>` values.
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and
   verification workflows.


### PR DESCRIPTION
## Summary
- store `DacsByte` level data as `View<[u8]>`
- adapt builder and tests
- document change in CHANGELOG

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6877d2ab7f8483229f74f8bf11b8dace