### PR TITLE
Fix doc link and update inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,5 @@
 - Updated benchmarks to use `jerky::bit_vector` imports.
 - Removed the WaveletMatrix iterator caching TODO and inventory entry after
   benchmarking showed only a 3% performance gain.
+- Fixed a stale doc link referencing the old `bit_vectors` module.
+- Removed completed documentation cleanup tasks from `INVENTORY.md`.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -8,9 +8,7 @@
 - Provide more usage examples and documentation.
 - Evaluate additional succinct data structures to include.
 - Investigate alternative dense-select index strategies to replace removed `DArrayIndex`.
-- Audit documentation for broken module links after recent restructuring.
-- Ensure README and examples reference the new `bit_vector` module name.
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
-- Benchmarks still used the old `jerky::bit_vectors` path, breaking compilation.
+- Fix typo "softwere" in `bench/README.md`.

--- a/src/char_sequences/mod.rs
+++ b/src/char_sequences/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Introduction
 //!
-//! *Character sequences* are a generalization of [`bit_vectors`](crate::bit_vector),
+//! *Character sequences* are a generalization of [bit vectors](crate::bit_vector),
 //! whose elements are drawn from an alphabet $`\Sigma = \{ 0,1,\dots,\sigma - 1 \}`$.
 //!
 //! Let $`(c_0, c_1, \dots, c_{n-1}) \in \Sigma^{n} `$ be a sequence of $`n`$ characters.


### PR DESCRIPTION
## Summary
- fix stale doc link referencing bit vectors
- note completion of docs clean-up tasks
- remove completed TODOs from inventory

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: `rustup` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be6d3846883229e76a816e55d17d3