### PR TITLE
Fix bench README typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@
   benchmarking showed only a 3% performance gain.
 - Fixed a stale doc link referencing the old `bit_vectors` module.
 - Removed completed documentation cleanup tasks from `INVENTORY.md`.
+- Fixed a typo in `bench/README.md`.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -11,4 +11,3 @@
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
-- Fix typo "softwere" in `bench/README.md`.

--- a/bench/README.md
+++ b/bench/README.md
@@ -83,4 +83,4 @@ RUSTFLAGS="-C target-cpu=native" cargo bench
 
 ## License
 
-The softwere under `data` are generated from [Pizza&Chili Corpus](http://pizzachili.dcc.uchile.cl/texts.html) and follow [LGPL License](https://www.gnu.org/licenses/lgpl-3.0.html).
+The software under `data` are generated from [Pizza&Chili Corpus](http://pizzachili.dcc.uchile.cl/texts.html) and follow [LGPL License](https://www.gnu.org/licenses/lgpl-3.0.html).


### PR DESCRIPTION
## Summary
- fix `softwere` typo in bench README
- remove completed inventory item
- document fix in CHANGELOG

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687bfd5dfb648322913b16540aea4fc3