### PR TITLE
Add cleanup task for README example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Replaced `DArrayFullIndex` with new `DArrayIndex` that uses const generics
   to optionally include `select1` and `select0` support.
 - Introduced `CompactVectorBuilder` mutable APIs `push_int`, `set_int`, and `extend`.
+- Added README usage example demonstrating basic bit vector operations.
 - Added `freeze()` on `CompactVectorBuilder` yielding an immutable `CompactVector` backed by `BitVector<NoIndex>`.
 - `CompactVector::new` and `with_capacity` now return builders; other constructors build via the builder pattern.
 - Wavelet matrix and DACs builders now use `BitVectorBuilder` for temporary bit

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -10,3 +10,8 @@
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
+- bit_vector prelude lacks common types like `BitVectorBuilder` and `Rank9SelIndex`,
+  forcing verbose imports in examples.
+- Import paths for `BitVectorBuilder` include a redundant `bit_vector` module
+  segment, e.g. `jerky::bit_vector::bit_vector::BitVectorBuilder`.
+  Cleanup the module layout so examples only need `jerky::bit_vector`.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ is backed by `anybytes::View`. The data can be serialized with
 allowing zero-copy loading from an mmap or any other source by passing the
 byte region to `Bytes::from_source`.
 
+## Usage example
+
+The snippet below shows how to build a bit vector with a rank/select index and
+perform a few basic queries:
+
+```rust
+use jerky::bit_vector::{bit_vector::BitVectorBuilder, rank9sel::inner::Rank9SelIndex, prelude::*};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut builder = BitVectorBuilder::new();
+    builder.extend_bits([true, false, true, false, true]);
+    let bv = builder.freeze::<Rank9SelIndex>();
+
+    assert_eq!(bv.num_bits(), 5);
+    assert_eq!(bv.rank1(4), Some(2));
+    assert_eq!(bv.select1(1), Some(2));
+    Ok(())
+}
+```
+
 ## Licensing
 
 Licensed under either of


### PR DESCRIPTION
## Summary
- revert the README example import so it matches current module layout
- clarify the bit vector cleanup task in `INVENTORY.md`
- remove incorrect changelog note about fixing the README import

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fc2b4667883229ae8f80795179358