### PR TITLE
Add CompactVector usage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@
 - Split inspection tests so each assertion stands alone.
 - Documented `WaveletMatrix` usage in `README.md`.
 - Moved README usage examples to runnable files in `examples/`.
+- Added `compact_vector` example showing construction and retrieval.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -5,7 +5,6 @@
 
 ## Desired Functionality
 - Provide more usage examples and documentation.
-- Add usage example demonstrating `CompactVector` construction and retrieval.
 - Evaluate additional succinct data structures to include.
 - Investigate alternative dense-select index strategies to replace removed `DArrayIndex`.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ byte region to `Bytes::from_source`.
 
 ## Examples
 
-See the [examples](examples/) directory for runnable usage demos.
+See the [examples](examples/) directory for runnable usage demos, including
+`bit_vector`, `wavelet_matrix`, and `compact_vector`.
 
 ## Licensing
 

--- a/examples/compact_vector.rs
+++ b/examples/compact_vector.rs
@@ -1,0 +1,13 @@
+use jerky::int_vectors::CompactVectorBuilder;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Build a vector storing integers within 3 bits each.
+    let mut builder = CompactVectorBuilder::new(3)?;
+    builder.extend([7, 2, 5])?;
+    let cv = builder.freeze();
+
+    assert_eq!(cv.len(), 3);
+    assert_eq!(cv.get_int(0), Some(7));
+    assert_eq!(cv.get_int(2), Some(5));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a runnable example showing CompactVector construction and retrieval
- mention available examples in the README
- note new example in CHANGELOG
- remove completed inventory item

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68803a983d2483228a0a5e256cb91945