### PR TITLE
Add BitVectorBuilder from_bit constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Replaced the old `BitVector` with the generic `BitVector<I>` and renamed the
   mutable variant to `RawBitVector`.
 - Extended `BitVectorBuilder` with `push_bits` and `set_bit` APIs.
+- Added `from_bit` constructor on `BitVectorBuilder` for repeating a single bit.
 - `DacsByte` now stores level data as zero-copy `View<[u8]>` values.
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and


### PR DESCRIPTION
## Summary
- implement `BitVectorBuilder::from_bit` to create repeated bits
- test new constructor
- note capability in CHANGELOG

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688105a70820832299bcf6c391e0f4bd