### PR TITLE
Remove obsolete size_in_bytes helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `from_bit` constructor on `BitVectorBuilder` for repeating a single bit.
 - `DacsByte` now stores level data as zero-copy `View<[u8]>` values.
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.
+- Removed deprecated `size_in_bytes` helpers.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and
   verification workflows.
 - Simplified CI workflow to run `scripts/preflight.sh` on pull requests.

--- a/src/bit_vector/mod.rs
+++ b/src/bit_vector/mod.rs
@@ -311,11 +311,6 @@ impl BitVectorData {
         Some(bits)
     }
 
-    /// Returns the number of bytes required for the old copy-based serialization.
-    pub fn size_in_bytes(&self) -> usize {
-        std::mem::size_of::<usize>() * (self.words.len() + 2)
-    }
-
     /// Serializes the data into a [`Bytes`] buffer.
     pub fn to_bytes(&self) -> (usize, Bytes) {
         (self.len, self.words.clone().bytes())

--- a/src/bit_vector/rank9sel/inner.rs
+++ b/src/bit_vector/rank9sel/inner.rs
@@ -516,23 +516,6 @@ impl<const SELECT1: bool, const SELECT0: bool> Rank9SelIndex<SELECT1, SELECT0> {
         }
         Bytes::from_source(store)
     }
-
-    /// Returns the number of bytes required for the old copy-based serialization.
-    pub fn size_in_bytes(&self) -> usize {
-        let mut mem = std::mem::size_of::<usize>() * 2;
-        mem += std::mem::size_of::<usize>() * self.block_rank_pairs.len();
-        mem += std::mem::size_of::<bool>();
-        if let Some(hints) = &self.select1_hints {
-            mem += std::mem::size_of::<usize>();
-            mem += std::mem::size_of::<usize>() * hints.len();
-        }
-        mem += std::mem::size_of::<bool>();
-        if let Some(hints) = &self.select0_hints {
-            mem += std::mem::size_of::<usize>();
-            mem += std::mem::size_of::<usize>() * hints.len();
-        }
-        mem
-    }
 }
 
 impl<const SELECT1: bool, const SELECT0: bool> crate::bit_vector::BitVectorIndex

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 use anyhow::{anyhow, Result};
 
 use crate::bit_vector::{
-    Access, BitVector, BitVectorBuilder, BitVectorIndex, NumBits, Rank, Rank9SelIndex, Select,
+    Access, BitVector, BitVectorBuilder, BitVectorIndex, NumBits, Rank, Select,
 };
 use crate::int_vectors::{CompactVector, CompactVectorBuilder};
 use crate::utils;
@@ -596,19 +596,6 @@ where
     #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.wm.len(), Some(self.wm.len()))
-    }
-}
-
-impl WaveletMatrix<Rank9SelIndex> {
-    /// Returns the number of bytes required for the old copy-based serialization.
-    pub fn size_in_bytes(&self) -> usize {
-        std::mem::size_of::<usize>()
-            + self
-                .layers
-                .iter()
-                .map(|l| l.data.size_in_bytes() + l.index.size_in_bytes())
-                .sum::<usize>()
-            + std::mem::size_of::<usize>()
     }
 }
 

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -510,13 +510,6 @@ impl std::fmt::Debug for CompactVector {
     }
 }
 
-impl CompactVector {
-    /// Returns the number of bytes required for the old copy-based serialization.
-    pub fn size_in_bytes(&self) -> usize {
-        self.chunks.data.size_in_bytes() + std::mem::size_of::<usize>() * 2
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -293,24 +293,6 @@ impl Iterator for Iter<'_> {
     }
 }
 
-impl DacsByte {
-    /// Returns the number of bytes required for the old copy-based serialization.
-    pub fn size_in_bytes(&self) -> usize {
-        std::mem::size_of::<usize>()
-            + self
-                .data
-                .iter()
-                .map(|v| std::mem::size_of::<usize>() + v.len())
-                .sum::<usize>()
-            + std::mem::size_of::<usize>()
-            + self
-                .flags
-                .iter()
-                .map(|f| f.data.size_in_bytes() + f.index.size_in_bytes())
-                .sum::<usize>()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- drop deprecated `size_in_bytes` functions
- update docs
- keep zero‑copy `to_bytes` helpers

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68814a229b908322a143ed49c44fe524