### PR TITLE
Make DacsByte::from_slice generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Made `DacsByte` generic over its flag index type with a default of `Rank9SelIndex`.
+- `DacsByte::from_slice` now accepts a generic index type, removing `from_slice_with_index`.
 - Added `BitVectorBuilder` and zero-copy `BitVectorData` backed by `anybytes::View`.
 - Introduced `IndexBuilder` trait with a `Built` type and adjusted serialization helpers.
 - Rename crate to `succdisk` to reflect on-disk succinct data structures.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -7,6 +7,8 @@
 - Provide more usage examples and documentation.
 - Evaluate additional succinct data structures to include.
 - Investigate alternative dense-select index strategies to replace removed `DArrayIndex`.
+- Explore additional index implementations leveraging the new generic `DacsByte<I>`.
+- Demonstrate the generic `from_slice` usage in examples and docs.
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.

--- a/src/int_vectors/mod.rs
+++ b/src/int_vectors/mod.rs
@@ -37,7 +37,10 @@
 //! ## Compressed format with Directly Addressable Codes
 //!
 //! [`DacsByte`] is a compressed data structure using Directly Addressable Codes (DACs),
-//! a randomly-accessible variant of the VByte encoding scheme.
+//! a randomly-accessible variant of the VByte encoding scheme. `DacsByte<I>` lets
+//! you choose the [`BitVectorIndex`](crate::bit_vector::BitVectorIndex) type `I`
+//! for its internal flag vectors. The default is
+//! [`Rank9SelIndex`](crate::bit_vector::rank9sel::Rank9SelIndex).
 //!
 //! Let
 //!
@@ -56,9 +59,10 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use jerky::bit_vector::rank9sel::Rank9SelIndex;
 //! use jerky::int_vectors::{DacsByte, prelude::*};
 //!
-//! let seq = DacsByte::build_from_slice(&[5, 0, 100000, 334])?;
+//! let seq = DacsByte::<Rank9SelIndex>::build_from_slice(&[5, 0, 100000, 334])?;
 //!
 //! assert_eq!(seq.num_vals(), 4);
 //!


### PR DESCRIPTION
## Summary
- replace `from_slice_with_index` with a generic `from_slice`
- update docs and tests to specify the index type explicitly
- log the API change in `CHANGELOG.md` and note follow-up work in `INVENTORY.md`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688167a1ceb483229c2114a94be78676