### PR TITLE
Implement CompactVector serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added `CompactVector::to_bytes` and `from_bytes` for zero-copy serialization.
 - Made `DacsByte` generic over its flag index type with a default of `Rank9SelIndex`.
 - `DacsByte::from_slice` now accepts a generic index type, removing `from_slice_with_index`.
 - Added `BitVectorBuilder` and zero-copy `BitVectorData` backed by `anybytes::View`.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,6 +9,7 @@
 - Investigate alternative dense-select index strategies to replace removed `DArrayIndex`.
 - Explore additional index implementations leveraging the new generic `DacsByte<I>`.
 - Demonstrate the generic `from_slice` usage in examples and docs.
+- Show `CompactVector::to_bytes` and `from_bytes` in examples.
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ is backed by `anybytes::View`. The data can be serialized with
 `BitVectorData::to_bytes` and reconstructed using `BitVectorData::from_bytes`,
 allowing zero-copy loading from an mmap or any other source by passing the
 byte region to `Bytes::from_source`.
+`CompactVector` offers similar helpers: `CompactVector::to_bytes` returns a
+metadata struct along with the raw bytes, and `CompactVector::from_bytes`
+reconstructs the vector from that information.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- add a metadata struct for CompactVector serialization
- make `to_bytes` return `(CompactVectorMeta, Bytes)`
- require metadata for `from_bytes`
- update tests and docs

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688182c53270832289c354209e0b6637