### PR TITLE
Remove size_in_bytes usage

### DIFF
--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -24,7 +24,9 @@ fn show_memories(p: f64) {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
         let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndex>();
-        idx.data.size_in_bytes() + idx.index.size_in_bytes()
+        let (len, data) = idx.data.to_bytes();
+        let index = idx.index.to_bytes();
+        data.as_ref().len() + index.as_ref().len() + std::mem::size_of_val(&len)
     };
     print_memory("BitVector<Rank9SelIndex>", bytes);
 
@@ -32,7 +34,9 @@ fn show_memories(p: f64) {
         let mut b = BitVectorBuilder::new();
         b.extend_bits(bits.iter().cloned());
         let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndex>();
-        idx.data.size_in_bytes() + idx.index.size_in_bytes()
+        let (len, data) = idx.data.to_bytes();
+        let index = idx.index.to_bytes();
+        data.as_ref().len() + index.as_ref().len() + std::mem::size_of_val(&len)
     };
     print_memory("BitVector<Rank9SelIndex> (with select hints)", bytes);
 }

--- a/bench/src/mem_chrseq.rs
+++ b/bench/src/mem_chrseq.rs
@@ -33,7 +33,16 @@ fn show_memories(title: &str, text: &CompactVector) {
 
     let bytes = {
         let idx = WaveletMatrix::<Rank9SelIndex>::new(text.clone()).unwrap();
-        idx.size_in_bytes()
+        let layer_bytes: usize = idx
+            .layers
+            .iter()
+            .map(|bv| {
+                let (_, data) = bv.data.to_bytes();
+                let index = bv.index.to_bytes();
+                data.as_ref().len() + index.as_ref().len()
+            })
+            .sum();
+        layer_bytes + std::mem::size_of::<usize>()
     };
     print_memory("WaveletMatrix<Rank9SelIndex>", bytes, text.len());
 }


### PR DESCRIPTION
## Summary
- drop old `size_in_bytes()` calls from bench utilities
- compute memory usage directly from serialized bytes

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688286d3cfb08322b7584966ecaeab1c