### PR TITLE
Add zero-copy WaveletMatrix serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Added `WaveletMatrix::to_bytes` and `WaveletMatrix::from_bytes` returning metadata and bytes for zero-copy persistence.
+- Documented the serialized `WaveletMatrix` layout with ASCII art.
 - Made `DacsByte` generic over its flag index type with a default of `Rank9SelIndex`.
 - `DacsByte::from_slice` now accepts a generic index type, removing `from_slice_with_index`.
 - Added `BitVectorBuilder` and zero-copy `BitVectorData` backed by `anybytes::View`.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,6 +9,7 @@
 - Investigate alternative dense-select index strategies to replace removed `DArrayIndex`.
 - Explore additional index implementations leveraging the new generic `DacsByte<I>`.
 - Demonstrate the generic `from_slice` usage in examples and docs.
+- Provide serialization helpers for additional structures beyond `WaveletMatrix`.
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ is backed by `anybytes::View`. The data can be serialized with
 allowing zero-copy loading from an mmap or any other source by passing the
 byte region to `Bytes::from_source`.
 
+`WaveletMatrix` sequences share this layout and can be serialized with
+`WaveletMatrix::to_bytes` (returning metadata and bytes) and reconstructed
+using `WaveletMatrix::from_bytes`.
+
+The byte buffer returned by `to_bytes` stores each bit-vector layer
+contiguously. Given `num_words = ceil(len / WORD_LEN)`, the layout is:
+
+```
+bytes:
++------------+------------+-----+
+| layer 0    | layer 1    | ... |
+| num_words  | num_words  |     |
++------------+------------+-----+
+```
+where each segment contains `num_words` consecutive `usize` words for a layer.
+
 ## Examples
 
 See the [examples](examples/) directory for runnable usage demos, including


### PR DESCRIPTION
## Summary
- implement `WaveletMatrix::to_bytes` and `::from_bytes` returning metadata + bytes
- document the updated API
- track follow-up serialization ideas in the inventory
- document the byte layout with ASCII art

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688182ef663c8322854a0d4a2146f574