### PR TITLE
Add DacsByte byte serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Extended `BitVectorBuilder` with `push_bits` and `set_bit` APIs.
 - Added `from_bit` constructor on `BitVectorBuilder` for repeating a single bit.
 - `DacsByte` now stores level data as zero-copy `View<[u8]>` values.
+- Added `to_bytes` and `from_bytes` on `DacsByte` for zero-copy serialization.
+- Documented the byte layout produced by `DacsByte::to_bytes` with ASCII art.
+- Flags are serialized before level data to eliminate padding.
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.
 - Removed deprecated `size_in_bytes` helpers.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,6 +9,7 @@
 - Investigate alternative dense-select index strategies to replace removed `DArrayIndex`.
 - Explore additional index implementations leveraging the new generic `DacsByte<I>`.
 - Demonstrate the generic `from_slice` usage in examples and docs.
+- Showcase `DacsByte` byte serialization in an example.
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ is backed by `anybytes::View`. The data can be serialized with
 `BitVectorData::to_bytes` and reconstructed using `BitVectorData::from_bytes`,
 allowing zero-copy loading from an mmap or any other source by passing the
 byte region to `Bytes::from_source`.
+`DacsByte` sequences support a similar interface with `to_bytes` returning
+metadata alongside the byte slice and `from_bytes` rebuilding the sequence
+using that metadata.
+
+```text
+Bytes layout from `DacsByte::to_bytes`:
+
+| flag[0] words | flag[1] words | ... | flag[n-2] words | level[0] data | level[1] data | ... | level[n-1] data |
+
+The flag vectors come first and store native-endian `usize` words. The level
+data immediately follows without any padding.
+```
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- support `to_bytes` and `from_bytes` for `DacsByte`
- round-trip test for the new APIs
- document ability to serialize DACs
- record future task about examples
- store serialization metadata in fixed arrays
- adjust DacsByte metadata to use vectors instead of arrays
- document DacsByte byte layout with ASCII diagram
- flags are serialized before level data to remove padding

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688182d5428083228f2385f19d0ee606