### PR TITLE
Use single buffer for DacsByte bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `to_bytes` and `from_bytes` on `DacsByte` for zero-copy serialization.
 - Documented the byte layout produced by `DacsByte::to_bytes` with ASCII art.
 - Flags are serialized before level data to eliminate padding.
+- `DacsByte` stores all flags and levels in one contiguous byte buffer and `to_bytes` simply clones this buffer.
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.
 - Removed deprecated `size_in_bytes` helpers.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and


### PR DESCRIPTION
## Summary
- store all DacsByte data and flags in a single `Bytes` field
- build zero‑copy flag and level views from this buffer
- return this buffer directly from `to_bytes`
- keep `from_bytes` consistent with new layout
- document the change in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883d65697f8832285581ab630609545