### PR TITLE
Switch anybytes dependency to git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - `DacsByte` now stores level data as zero-copy `View<[u8]>` values.
 - Added `to_bytes` and `from_bytes` on `DacsByte` for zero-copy serialization.
 - Documented the byte layout produced by `DacsByte::to_bytes` with ASCII art.
+- Switched `anybytes` dependency to track the upstream Git repository for the
+  latest changes.
 - Flags are serialized before level data to eliminate padding.
 - `DacsByte` stores all flags and levels in one contiguous byte buffer and `to_bytes` simply clones this buffer.
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.61.0"
 [dependencies]
 anyhow = "1.0"
 num-traits = "0.2.15"
-anybytes = { version = "0.19", features = ["zerocopy"] }
+anybytes = { git = "https://github.com/triblespace/anybytes", features = ["zerocopy"] }
 zerocopy = "0.8"
 
 [features]


### PR DESCRIPTION
## Summary
- use the upstream `anybytes` repository as a git dependency
- note the change in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883e8b71dc883228769a4cd2b9b749d