### PR TITLE
Remove stored bytes field from data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - `DacsByte::from_slice` now accepts a generic index type, removing `from_slice_with_index`.
 - Added `BitVectorBuilder` and zero-copy `BitVectorData` backed by `anybytes::View`.
 - Introduced `IndexBuilder` trait with a `Built` type and adjusted serialization helpers.
-- `Rank9SelIndex` now stores its serialized bytes internally and `to_bytes` returns this buffer.
 - Rename crate to `succdisk` to reflect on-disk succinct data structures.
 - Rename crate from `succdisk` to `jerky`.
 - Replaced the old `BitVector` with the generic `BitVector<I>` and renamed the
@@ -20,8 +19,9 @@
 - Documented the byte layout produced by `DacsByte::to_bytes` with ASCII art.
 - Switched `anybytes` dependency to track the upstream Git repository for the
   latest changes.
+- Removed internal byte buffers from data structures; `WaveletMatrix`,
+  `DacsByte`, and `Rank9SelIndex` no longer store a `Bytes` field.
 - Flags are serialized before level data to eliminate padding.
-- `DacsByte` stores all flags and levels in one contiguous byte buffer and `to_bytes` simply clones this buffer.
 - Added `get_bits` methods to `BitVectorData` and `BitVector`.
 - Removed deprecated `size_in_bytes` helpers.
 - Added `scripts/devtest.sh` and `scripts/preflight.sh` for testing and
@@ -66,4 +66,3 @@
 - Documented `WaveletMatrix` usage in `README.md`.
 - Moved README usage examples to runnable files in `examples/`.
 - Added `compact_vector` example showing construction and retrieval.
-- WaveletMatrix now stores its serialized word buffer for zero-copy access and preallocates building memory.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -15,3 +15,4 @@
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
+- Revisit zero-copy storage strategy: avoid extra copies when storing serialized bytes in structures.

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -58,7 +58,6 @@ const MAX_LEVELS: usize = (usize::BITS as usize + LEVEL_WIDTH - 1) / LEVEL_WIDTH
 ///   codes." Information Processing & Management, 49(1), 392-404, 2013.
 #[derive(Clone, PartialEq, Eq)]
 pub struct DacsByte<I = Rank9SelIndex> {
-    bytes: Bytes,
     data: Vec<View<[u8]>>,
     flags: Vec<BitVector<I>>,
 }
@@ -132,96 +131,41 @@ impl<I: BitVectorIndex> DacsByte<I> {
         assert_ne!(num_levels, 0);
 
         if num_levels == 1 {
-            let buf: Vec<u8> = vals
+            let data: Vec<_> = vals
                 .iter()
                 .map(|x| u8::try_from(x.to_usize().unwrap()).unwrap())
                 .collect();
-            let bytes = Bytes::from_source(buf);
-            let data = vec![bytes.clone().view::<[u8]>().unwrap()];
             return Ok(Self {
-                bytes,
-                data,
+                data: vec![Bytes::from_source(data).view::<[u8]>().unwrap()],
                 flags: vec![],
             });
         }
 
-        let mut level_data = vec![vec![]; num_levels];
-        let mut flag_builders = vec![BitVectorBuilder::new(); num_levels - 1];
+        let mut data = vec![vec![]; num_levels];
+        let mut flags = vec![BitVectorBuilder::new(); num_levels - 1];
 
         for x in vals {
             let mut x = x.to_usize().unwrap();
             for j in 0..num_levels {
-                level_data[j].push(u8::try_from(x & LEVEL_MASK).unwrap());
+                data[j].push(u8::try_from(x & LEVEL_MASK).unwrap());
                 x >>= LEVEL_WIDTH;
                 if j == num_levels - 1 {
                     assert_eq!(x, 0);
                     break;
                 } else if x == 0 {
-                    flag_builders[j].push_bit(false);
+                    flags[j].push_bit(false);
                     break;
                 }
-                flag_builders[j].push_bit(true);
+                flags[j].push_bit(true);
             }
         }
 
-        use std::mem::size_of;
-
-        let usize_size = size_of::<usize>();
-        let mut flag_bytes = Vec::new();
-        let mut flag_info = Vec::with_capacity(flag_builders.len());
-        for b in flag_builders.into_iter() {
-            let (len_bits, bytes) = b.into_bytes();
-            let num_words = bytes.as_ref().len() / usize_size;
-            flag_info.push((len_bits, num_words));
-            flag_bytes.push(bytes);
-        }
-
-        let level_lens: Vec<usize> = level_data.iter().map(|v| v.len()).collect();
-
-        let total_flags: usize = flag_info.iter().map(|(_, w)| w * usize_size).sum();
-        let total_levels: usize = level_lens.iter().sum();
-        let mut buf = Vec::with_capacity(total_flags + total_levels);
-        let mut flag_offsets = Vec::with_capacity(flag_bytes.len());
-        for bytes in &flag_bytes {
-            flag_offsets.push(buf.len());
-            buf.extend_from_slice(bytes.as_ref());
-        }
-        let mut level_offsets = Vec::with_capacity(level_data.len());
-        for level in &level_data {
-            level_offsets.push(buf.len());
-            buf.extend_from_slice(level);
-        }
-
-        let bytes = Bytes::from_source(buf);
-        let mut flags = Vec::with_capacity(flag_offsets.len());
-        for ((len_bits, num_words), offset) in flag_info.into_iter().zip(flag_offsets) {
-            let start = offset;
-            let end = start + num_words * usize_size;
-            let words_view = bytes
-                .slice_to_bytes(&bytes.as_ref()[start..end])
-                .ok_or_else(|| anyhow!("invalid slice"))?
-                .view::<[usize]>()
-                .map_err(|e| anyhow!(e))?;
-            let data = bit_vector::BitVectorData {
-                words: words_view,
-                len: len_bits,
-            };
-            let index = I::build(&data);
-            flags.push(bit_vector::BitVector { data, index });
-        }
-
-        let mut data = Vec::with_capacity(level_offsets.len());
-        for (offset, len) in level_offsets.into_iter().zip(level_lens) {
-            let start = offset;
-            let end = start + len;
-            let view_bytes = bytes
-                .slice_to_bytes(&bytes.as_ref()[start..end])
-                .ok_or_else(|| anyhow!("invalid slice"))?;
-            let view = view_bytes.view::<[u8]>().map_err(|e| anyhow!(e))?;
-            data.push(view);
-        }
-
-        Ok(Self { bytes, data, flags })
+        let flags = flags.into_iter().map(|bvb| bvb.freeze::<I>()).collect();
+        let data = data
+            .into_iter()
+            .map(|v| Bytes::from_source(v).view::<[u8]>().unwrap())
+            .collect();
+        Ok(Self { data, flags })
     }
 
     /// Creates an iterator for enumerating integers.
@@ -291,13 +235,24 @@ impl<I: BitVectorIndex> DacsByte<I> {
             })
             .collect::<Vec<_>>();
 
+        let mut buf: Vec<u8> = Vec::new();
+        for flag in &self.flags {
+            for &word in flag.data.words.as_ref() {
+                buf.extend_from_slice(&word.to_ne_bytes());
+            }
+        }
+
+        for level in &self.data {
+            buf.extend_from_slice(level.as_ref());
+        }
+
         (
             DacsByteMeta {
                 num_levels: self.data.len(),
                 level_lens,
                 flag_meta,
             },
-            self.bytes.clone(),
+            Bytes::from_source(buf),
         )
     }
 
@@ -352,7 +307,7 @@ impl<I: BitVectorIndex> DacsByte<I> {
             cursor += len;
         }
 
-        Ok(Self { bytes, data, flags })
+        Ok(Self { data, flags })
     }
 }
 
@@ -360,7 +315,6 @@ impl<I: BitVectorIndex> Default for DacsByte<I> {
     fn default() -> Self {
         Self {
             // Needs a single level at least.
-            bytes: Bytes::empty(),
             data: vec![Bytes::empty().view::<[u8]>().unwrap()],
             flags: vec![],
         }


### PR DESCRIPTION
## Summary
- revert the merge commits that added `bytes` fields to `WaveletMatrix`, `DacsByte`, and `Rank9SelIndex`
- document the rollback in `CHANGELOG.md`
- note future investigation in `INVENTORY.md`

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688a634a47308322807515ce4ad2a26a