### PR TITLE
docs: add ByteArea metadata examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,54 @@
 # Changelog
 
 ## Unreleased
-- Added `WaveletMatrix::to_bytes` and `WaveletMatrix::from_bytes` returning metadata and bytes for zero-copy persistence.
-- Documented the serialized `WaveletMatrix` layout with ASCII art.
-- Added `CompactVector::to_bytes` and `from_bytes` for zero-copy serialization.
+- Introduced a `Serializable` trait for metadata-based reconstruction and
+  implemented it for `CompactVector`, `DacsByte`, and `WaveletMatrix`.
+- Audited `DacsByte` and `WaveletMatrix` to leverage `SectionHandle::view`
+  during deserialization, removing legacy `slice_to_bytes` helpers and fully
+  adopting the `ByteArea`-backed reconstruction path.
+- Switched internal bit-vector words and handles from `usize` to `u64`, removing
+  unsafe handle transmutes in `WaveletMatrixBuilder` and fixing word size to
+  64-bit.
+  - Reversed remaining layers and popped in `WaveletMatrixBuilder::freeze`
+    to avoid repeated vector shifts.
+  - `WaveletMatrixMeta` now stores a handle slice of per-layer handles, and
+    `WaveletMatrixBuilder` allocates that slice from the `SectionWriter`.
+  - `WaveletMatrixBuilder::with_capacity` records each layer's handle up front,
+    eliminating handle assignment during `freeze`.
+  - Switched to the zerocopy `SectionHandle` from `anybytes`, removing the
+    interim `HandleRepr` shim.
+  - Added `WaveletMatrixBuilder` for fixed-size construction, writing raw bits per
+    layer and stably partitioning them on `freeze`; `WaveletMatrix::from_iter`
+    now builds via this builder without requiring iterator cloning.
+  - `WaveletMatrix` construction now goes through `from_iter`, which allocates
+    layer bitvectors from a `SectionWriter` and consumes a single
+    `ExactSizeIterator` without temporary `CompactVector` partitions.
+  - `CompactVector::iter` now implements `ExactSizeIterator` to support the new
+    constructor.
+  - `WaveletMatrixBuilder::freeze` partitions layers in place, removing the
+    temporary bit buffer previously used during construction.
+  - Removed `order` and `next_order` buffers by sorting remaining layers in
+    place during each `freeze` step.
+  - Optimized `WaveletMatrixBuilder::freeze` using stable per-layer partitions
+    and cycle-based permutations, reducing layer processing to linear time.
+  - Replaced the `perm` array with a scratch `visited` bitmap and cycle
+    rotations so each level permutes lower layers in place with only `O(n)`
+    extra bits.
+  - Stored row suffix bits in a `usize` during cycle rotations, removing the
+    temporary `Vec<bool>` from `rotate_cycle_over_lower_levels`.
+  - Reused `BitVectorBuilder` as the scratch `visited` bitmap for
+    wavelet-matrix construction, eliminating the separate `BitArrayBuilder`.
+  - Added `swap_bits` helper to `BitVectorBuilder` for in-place bit exchanges.
+  - Reworked `WaveletMatrix::from_iter` to require a cloneable iterator and
+    build layers in two passes without temporary buffers.
+- Rewrote `CompactVectorBuilder` to use fixed-size `set_int` and `set_ints`
+  APIs, removing `push_int`/`extend` and updating builders and examples.
+- Added `with_capacity` constructor on `BitVectorBuilder` and honored capacity in
+  `CompactVectorBuilder::with_capacity` to pre-allocate bit storage.
+- Replaced `BitVectorBuilder::new` with `with_capacity` that allocates from an
+  `anybytes::ByteArea` section and plumbed `SectionWriter` through
+  `CompactVectorBuilder` and wavelet matrix builders.
+- Builders now track capacity and error when pushes exceed the reserved size.
 - Made `DacsByte` generic over its flag index type with a default of `Rank9SelIndex`.
 - `DacsByte::from_slice` now accepts a generic index type, removing `from_slice_with_index`.
 - Added `BitVectorBuilder` and zero-copy `BitVectorData` backed by `anybytes::View`.
@@ -12,11 +57,15 @@
 - Rename crate from `succdisk` to `jerky`.
 - Replaced the old `BitVector` with the generic `BitVector<I>` and renamed the
   mutable variant to `RawBitVector`.
-- Extended `BitVectorBuilder` with `push_bits` and `set_bit` APIs.
+- Replaced the push-based `BitVectorBuilder` with fixed-size `set_bit` and `set_bits` APIs and updated builders accordingly.
+- Added `set_bits_from_iter` to `BitVectorBuilder` and later revised it to take a
+  start offset and consume bits until the iterator ends or the builder is
+  full, leaving any unconsumed items to the caller.
 - Added `from_bit` constructor on `BitVectorBuilder` for repeating a single bit.
 - `DacsByte` now stores level data as zero-copy `View<[u8]>` values.
-- Added `to_bytes` and `from_bytes` on `DacsByte` for zero-copy serialization.
-- Documented the byte layout produced by `DacsByte::to_bytes` with ASCII art.
+- Replaced `to_bytes` helpers with `metadata` methods returning `SectionHandle`s
+  so structures can be reconstructed zero-copy via `from_bytes`.
+- Documented the byte layout for `DacsByte` sequences with ASCII art.
 - Switched `anybytes` dependency to track the upstream Git repository for the
   latest changes.
 - Removed internal byte buffers from data structures; `WaveletMatrix`,
@@ -31,13 +80,15 @@
 - `Rank9Sel` now stores a `BitVector<Rank9SelIndex>` built via `BitVectorBuilder`.
 - Replaced `DArrayFullIndex` with new `DArrayIndex` that uses const generics
   to optionally include `select1` and `select0` support.
-- Introduced `CompactVectorBuilder` mutable APIs `push_int`, `set_int`, and `extend`.
+- Introduced `CompactVectorBuilder` mutable APIs `set_int` and `set_ints`.
 - Simplified bit vector imports by re-exporting `BitVectorBuilder` and `Rank9SelIndex` and updating examples.
 - Moved the `bit_vector::bit_vector` module contents directly into `bit_vector` for cleaner paths.
+- Recorded future work items for a metadata serialization trait and
+  ByteArea-backed documentation examples.
 - Added README usage example demonstrating basic bit vector operations.
 - Removed `bit_vector::prelude`; import traits directly with `use jerky::bit_vector::*`.
 - Added `freeze()` on `CompactVectorBuilder` yielding an immutable `CompactVector` backed by `BitVector<NoIndex>`.
-- `CompactVector::new` and `with_capacity` now return builders; other constructors build via the builder pattern.
+- Removed `CompactVector::new`; use `with_capacity` to construct builders.
 - Wavelet matrix and DACs builders now use `BitVectorBuilder` for temporary bit
   vectors, storing only immutable `BitVector` data after construction.
 - Removed obsolete `RawBitVector` type.
@@ -66,3 +117,13 @@
 - Documented `WaveletMatrix` usage in `README.md`.
 - Moved README usage examples to runnable files in `examples/`.
 - Added `compact_vector` example showing construction and retrieval.
+- Serialized `WaveletMatrix` and `DacsByte` directly into a `ByteArea` to
+  avoid intermediate copies and guarantee contiguous layout.
+- Enabled doctests for `WaveletMatrix` by removing `ignore` fences from its
+  documentation examples.
+- `DacsByte::from_slice` now writes level bytes and flags directly into
+  `SectionWriter` buffers, removing the intermediate `Vec` allocations.
+- Stored per-level `DacsByte` handles in the byte arena, allowing
+  `DacsByteMeta` to reference a single handle slice like `WaveletMatrixMeta`.
+- Expanded examples and README with `ByteArea`/`SectionHandle` metadata
+  reconstruction for set-based APIs, adding a `dacs_byte` usage demo.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.61.0"
 [dependencies]
 anyhow = "1.0"
 num-traits = "0.2.15"
-anybytes = { git = "https://github.com/triblespace/anybytes", features = ["zerocopy"] }
+anybytes = { git = "https://github.com/triblespace/anybytes", features = ["zerocopy", "mmap"] }
 zerocopy = "0.8"
 
 [features]

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,9 +9,44 @@
 - Investigate alternative dense-select index strategies to replace removed `DArrayIndex`.
 - Explore additional index implementations leveraging the new generic `DacsByte<I>`.
 - Demonstrate the generic `from_slice` usage in examples and docs.
-- Showcase `DacsByte` byte serialization in an example.
-- Provide serialization helpers for additional structures beyond `WaveletMatrix`.
-- Show `CompactVector::to_bytes` and `from_bytes` in examples.
+- Apply `with_capacity` constructors across builders to avoid intermediate reallocations.
+- Transition builders to fixed-size APIs, removing growable variants.
+- Refactor builders and serializers to operate on `ByteArea` sections, enabling
+  zero-copy persistence across all structures.
+- Move `DacsByte` metadata arrays into the arena and store per-level handles
+  similar to `WaveletMatrixMeta`.
+- Add slice-based range setters for integer builders to minimize manual index
+  tracking during construction.
+- Provide bulk bit setters like `set_bits_from_slice` for `BitVectorBuilder`
+  to copy from packed data efficiently.
+- Provide convenience helpers to manage `ByteArea` and `SectionWriter` setup for
+  common builder use cases.
+- Audit remaining constructors for zero-capacity variants and decide whether to
+  offer explicit `empty` helpers instead of `with_capacity(0)`.
+- Allocate temporary wavelet-matrix buffers from `ByteArea` to avoid
+  intermediate `Vec` copies and ensure fully contiguous construction.
+- Provide a derive or macro to reduce boilerplate when implementing the
+  `Serializable` trait.
+- Consider a slice-based `WaveletMatrix` constructor to avoid requiring
+  cloneable iterators.
+ - Benchmark the cycle-based partitioning in `WaveletMatrixBuilder::freeze`
+   and explore more efficient permutation strategies.
+- Explore specialized rotation helpers for `BitVectorBuilder` to speed up
+  recursive partitioning without extra buffers.
+- Explore using `BitVectorBuilder` for other temporary bitmaps to reduce
+  scattered `Vec<bool>` allocations.
+- Review documentation examples across modules and convert remaining ignored
+  snippets into runnable doctests.
+- Explore iterating layer indices instead of reversing `remaining` to avoid
+  the upfront `reverse` cost in `WaveletMatrixBuilder::freeze`.
+- Audit integer-vector constructors for opportunities to allocate directly
+  from `SectionWriter` without temporary `Vec`s.
+- Document the fixed 64-bit word assumption across structures now that bit
+  vectors use `u64` internally.
+- Provide helpers on `SectionHandle` to derive typed sub-handles, reducing
+  manual offset math in complex `from_bytes` implementations like `DacsByte`.
+- Investigate slimming `DacsByte` per-level metadata to avoid storing unused
+  flag handles for the last level.
 
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.

--- a/README.md
+++ b/README.md
@@ -25,17 +25,22 @@ RUSTDOCFLAGS="--html-in-header katex.html" cargo doc --no-deps
 ## Zero-copy bit vectors
 
 `BitVectorBuilder` can build a bit vector whose underlying `BitVectorData`
-is backed by `anybytes::View`. The data can be serialized with
-`BitVectorData::to_bytes` and reconstructed using `BitVectorData::from_bytes`,
-allowing zero-copy loading from an mmap or any other source by passing the
-byte region to `Bytes::from_source`.
+is backed by `anybytes::View`. Metadata describing a stored sequence includes
+[`SectionHandle`](anybytes::area::SectionHandle)s so the raw
+`Bytes` returned by `ByteArea::freeze` can be handed to
+`BitVectorData::from_bytes` for zero‑copy reconstruction.
 
-`DacsByte` sequences support a similar interface with `to_bytes` returning
-metadata alongside the byte slice and `from_bytes` rebuilding the sequence
-using that metadata.
+Types following this pattern implement the [`Serializable`](src/serialization.rs) trait,
+which exposes a `metadata` accessor and a `from_bytes` constructor.
+
+`DacsByte` sequences expose a `metadata` method returning a descriptor with a
+handle to a slice of per-level handles. Each entry stores the flag bitvector
+handle (if any), its bit length, and the payload byte handle. `from_bytes`
+rebuilds the sequence using that metadata.
 
 ```text
-Bytes layout from `DacsByte::to_bytes`:
+Bytes layout for a `DacsByte` sequence (current builders place sections
+contiguously, though layout is fully described by the stored handles):
 
 | flag[0] words | flag[1] words | ... | flag[n-2] words | level[0] data | level[1] data | ... | level[n-1] data |
 
@@ -43,30 +48,34 @@ The flag vectors come first and store native-endian `usize` words. The level
 data immediately follows without any padding.
 ```
 
-`CompactVector` offers similar helpers: `CompactVector::to_bytes` returns a
-metadata struct along with the raw bytes, and `CompactVector::from_bytes`
-reconstructs the vector from that information.
+`CompactVector` and `WaveletMatrix` provide the same pattern: call `metadata`
+to obtain a descriptor with the required `SectionHandle`s, then hand both the
+metadata and the full `Bytes` region to `from_bytes`.
 
-`WaveletMatrix` sequences share this layout and can be serialized with
-`WaveletMatrix::to_bytes` (returning metadata and bytes) and reconstructed
-using `WaveletMatrix::from_bytes`.
+For a wavelet matrix the metadata stores a handle to a slice of per-layer
+handles. Each handle in that slice points to the native-endian `usize` words
+forming a single layer. Layers may reside anywhere in the arena and no longer
+need to be contiguous.
 
-The byte buffer returned by `to_bytes` stores each bit-vector layer
-contiguously. Given `num_words = ceil(len / WORD_LEN)`, the layout is:
+```rust
+use anybytes::ByteArea;
+use jerky::int_vectors::{CompactVector, CompactVectorBuilder};
 
+let mut area = ByteArea::new()?;
+let mut sections = area.sections();
+let mut builder = CompactVectorBuilder::with_capacity(3, 3, &mut sections)?;
+builder.set_ints(0..3, [7, 2, 5])?;
+let cv = builder.freeze();
+let meta = cv.metadata();
+let bytes = area.freeze()?;
+let view = CompactVector::from_bytes(meta, bytes.clone())?;
+assert_eq!(view.get_int(1), Some(2));
 ```
-bytes:
-+------------+------------+-----+
-| layer 0    | layer 1    | ... |
-| num_words  | num_words  |     |
-+------------+------------+-----+
-```
-where each segment contains `num_words` consecutive `usize` words for a layer.
 
 ## Examples
 
 See the [examples](examples/) directory for runnable usage demos, including
-`bit_vector`, `wavelet_matrix`, and `compact_vector`.
+`bit_vector`, `compact_vector`, `dacs_byte`, and `wavelet_matrix`.
 
 ## Licensing
 

--- a/bench/benches/timing_bitvec_rank.rs
+++ b/bench/benches/timing_bitvec_rank.rs
@@ -7,6 +7,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
 
+use anybytes::ByteArea;
 use jerky::bit_vector::{BitVector, BitVectorBuilder, NoIndex, Rank, Rank9SelIndex};
 
 const SAMPLE_SIZE: usize = 30;
@@ -39,15 +40,23 @@ fn run_queries<R: Rank>(idx: &R, queries: &[usize]) {
 
 fn perform_bitvec_rank(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], queries: &[usize]) {
     group.bench_function("jerky/BitVector", |b| {
-        let mut builder = BitVectorBuilder::new();
-        builder.extend_bits(bits.iter().cloned());
+        let mut area = ByteArea::new().unwrap();
+        let mut sections = area.sections();
+        let mut builder = BitVectorBuilder::with_capacity(bits.len(), &mut sections).unwrap();
+        for (i, &bval) in bits.iter().enumerate() {
+            builder.set_bit(i, bval).unwrap();
+        }
         let idx: BitVector<NoIndex> = builder.freeze();
         b.iter(|| run_queries(&idx, &queries));
     });
 
     group.bench_function("jerky/BitVector<Rank9SelIndex>", |b| {
-        let mut builder = BitVectorBuilder::new();
-        builder.extend_bits(bits.iter().cloned());
+        let mut area = ByteArea::new().unwrap();
+        let mut sections = area.sections();
+        let mut builder = BitVectorBuilder::with_capacity(bits.len(), &mut sections).unwrap();
+        for (i, &bval) in bits.iter().enumerate() {
+            builder.set_bit(i, bval).unwrap();
+        }
         let idx = builder.freeze::<Rank9SelIndex>();
         b.iter(|| run_queries(&idx, &queries));
     });

--- a/bench/benches/timing_bitvec_select.rs
+++ b/bench/benches/timing_bitvec_select.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
+use anybytes::ByteArea;
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
@@ -42,15 +43,23 @@ fn run_queries<S: Select>(idx: &S, queries: &[usize]) {
 
 fn perform_bitvec_select(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], queries: &[usize]) {
     group.bench_function("jerky/BitVector", |b| {
-        let mut builder = BitVectorBuilder::new();
-        builder.extend_bits(bits.iter().cloned());
+        let mut area = ByteArea::new().unwrap();
+        let mut sections = area.sections();
+        let mut builder = BitVectorBuilder::with_capacity(bits.len(), &mut sections).unwrap();
+        for (i, &bval) in bits.iter().enumerate() {
+            builder.set_bit(i, bval).unwrap();
+        }
         let idx: BitVector<NoIndex> = builder.freeze();
         b.iter(|| run_queries(&idx, &queries));
     });
 
     group.bench_function("jerky/BitVector<Rank9SelIndex>", |b| {
-        let mut builder = BitVectorBuilder::new();
-        builder.extend_bits(bits.iter().cloned());
+        let mut area = ByteArea::new().unwrap();
+        let mut sections = area.sections();
+        let mut builder = BitVectorBuilder::with_capacity(bits.len(), &mut sections).unwrap();
+        for (i, &bval) in bits.iter().enumerate() {
+            builder.set_bit(i, bval).unwrap();
+        }
         let idx = builder.freeze::<Rank9SelIndex>();
         b.iter(|| run_queries(&idx, &queries));
     });

--- a/bench/benches/timing_intvec_access.rs
+++ b/bench/benches/timing_intvec_access.rs
@@ -7,6 +7,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
 
+use anybytes::ByteArea;
 use jerky::int_vectors::Access;
 
 const SAMPLE_SIZE: usize = 30;
@@ -87,7 +88,10 @@ fn perform_intvec_access(group: &mut BenchmarkGroup<WallTime>, vals: &[u32]) {
     });
 
     group.bench_function("jerky/DacsByte", |b| {
-        let idx = jerky::int_vectors::DacsByte::from_slice(vals).unwrap();
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
+        let idx = jerky::int_vectors::DacsByte::from_slice(vals, &mut writer).unwrap();
+        area.freeze().unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -1,3 +1,4 @@
+use anybytes::ByteArea;
 use jerky::bit_vector::{BitVector, BitVectorBuilder, Rank9SelIndex};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
@@ -21,22 +22,30 @@ fn show_memories(p: f64) {
     println!("[p = {p}]");
 
     let bytes = {
-        let mut b = BitVectorBuilder::new();
-        b.extend_bits(bits.iter().cloned());
+        let mut area = ByteArea::new().unwrap();
+        let mut sections = area.sections();
+        let mut b = BitVectorBuilder::with_capacity(bits.len(), &mut sections).unwrap();
+        for (i, &bv) in bits.iter().enumerate() {
+            b.set_bit(i, bv).unwrap();
+        }
         let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndex>();
-        let (len, data) = idx.data.to_bytes();
-        let index = idx.index.to_bytes();
-        data.as_ref().len() + index.as_ref().len() + std::mem::size_of_val(&len)
+        let len = idx.data.len;
+        let data_bytes = idx.data.words.bytes();
+        data_bytes.as_ref().len() + std::mem::size_of_val(&len)
     };
     print_memory("BitVector<Rank9SelIndex>", bytes);
 
     let bytes = {
-        let mut b = BitVectorBuilder::new();
-        b.extend_bits(bits.iter().cloned());
+        let mut area = ByteArea::new().unwrap();
+        let mut sections = area.sections();
+        let mut b = BitVectorBuilder::with_capacity(bits.len(), &mut sections).unwrap();
+        for (i, &bv) in bits.iter().enumerate() {
+            b.set_bit(i, bv).unwrap();
+        }
         let idx: BitVector<Rank9SelIndex> = b.freeze::<Rank9SelIndex>();
-        let (len, data) = idx.data.to_bytes();
-        let index = idx.index.to_bytes();
-        data.as_ref().len() + index.as_ref().len() + std::mem::size_of_val(&len)
+        let len = idx.data.len;
+        let data_bytes = idx.data.words.bytes();
+        data_bytes.as_ref().len() + std::mem::size_of_val(&len)
     };
     print_memory("BitVector<Rank9SelIndex> (with select hints)", bytes);
 }

--- a/examples/bit_vector.rs
+++ b/examples/bit_vector.rs
@@ -1,8 +1,13 @@
+use anybytes::ByteArea;
 use jerky::bit_vector::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut builder = BitVectorBuilder::new();
-    builder.extend_bits([true, false, true, false, true]);
+    let mut area = ByteArea::new()?;
+    let mut sections = area.sections();
+    let mut builder = BitVectorBuilder::with_capacity(5, &mut sections)?;
+    builder.set_bit(0, true)?;
+    builder.set_bit(2, true)?;
+    builder.set_bit(4, true)?;
     let bv = builder.freeze::<Rank9SelIndex>();
 
     assert_eq!(bv.num_bits(), 5);

--- a/examples/compact_vector.rs
+++ b/examples/compact_vector.rs
@@ -1,13 +1,19 @@
-use jerky::int_vectors::CompactVectorBuilder;
+use anybytes::ByteArea;
+use jerky::int_vectors::{CompactVector, CompactVectorBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build a vector storing integers within 3 bits each.
-    let mut builder = CompactVectorBuilder::new(3)?;
-    builder.extend([7, 2, 5])?;
+    let mut area = ByteArea::new()?;
+    let mut sections = area.sections();
+    let mut builder = CompactVectorBuilder::with_capacity(3, 3, &mut sections)?;
+    builder.set_ints(0..3, [7, 2, 5])?;
     let cv = builder.freeze();
+    let meta = cv.metadata();
+    let bytes = area.freeze()?;
+    let view = CompactVector::from_bytes(meta, bytes.clone())?;
 
-    assert_eq!(cv.len(), 3);
-    assert_eq!(cv.get_int(0), Some(7));
-    assert_eq!(cv.get_int(2), Some(5));
+    assert_eq!(view.len(), 3);
+    assert_eq!(view.get_int(0), Some(7));
+    assert_eq!(view.get_int(2), Some(5));
     Ok(())
 }

--- a/examples/dacs_byte.rs
+++ b/examples/dacs_byte.rs
@@ -1,0 +1,16 @@
+use anybytes::ByteArea;
+use jerky::bit_vector::Rank9SelIndex;
+use jerky::int_vectors::{Access, DacsByte};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut area = ByteArea::new()?;
+    let mut writer = area.sections();
+    let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 0, 100000, 334], &mut writer)?;
+    let meta = seq.metadata();
+    let bytes = area.freeze()?;
+    let view = DacsByte::<Rank9SelIndex>::from_bytes(meta, bytes.clone())?;
+
+    assert_eq!(view.access(2), Some(100000));
+    assert_eq!(seq, view);
+    Ok(())
+}

--- a/examples/wavelet_matrix.rs
+++ b/examples/wavelet_matrix.rs
@@ -1,16 +1,25 @@
+use anybytes::ByteArea;
 use jerky::bit_vector::Rank9SelIndex;
-use jerky::char_sequences::WaveletMatrix;
-use jerky::int_vectors::CompactVectorBuilder;
+use jerky::char_sequences::{WaveletMatrix, WaveletMatrixBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let text = "banana";
-    let mut builder = CompactVectorBuilder::new(8)?;
-    builder.extend(text.chars().map(|c| c as usize))?;
-    let wm = WaveletMatrix::<Rank9SelIndex>::new(builder.freeze())?;
+    let alph_size = ('n' as usize) + 1;
+    let mut area = ByteArea::new()?;
+    let mut sections = area.sections();
+    let ints: Vec<usize> = text.chars().map(|c| c as usize).collect();
+    let mut builder = WaveletMatrixBuilder::with_capacity(alph_size, ints.len(), &mut sections)?;
+    for (i, &x) in ints.iter().enumerate() {
+        builder.set_int(i, x)?;
+    }
+    let wm: WaveletMatrix<Rank9SelIndex> = builder.freeze()?;
+    let meta = wm.metadata();
+    let bytes = area.freeze()?;
+    let view = WaveletMatrix::<Rank9SelIndex>::from_bytes(meta, bytes.clone())?;
 
-    assert_eq!(wm.len(), text.len());
-    assert_eq!(wm.access(2), Some('n' as usize));
-    assert_eq!(wm.rank(4, 'a' as usize), Some(2));
-    assert_eq!(wm.select(1, 'n' as usize), Some(4));
+    assert_eq!(view.len(), text.len());
+    assert_eq!(view.access(2), Some('n' as usize));
+    assert_eq!(view.rank(4, 'a' as usize), Some(2));
+    assert_eq!(view.select(1, 'n' as usize), Some(4));
     Ok(())
 }

--- a/src/bit_vector/rank9sel/inner.rs
+++ b/src/bit_vector/rank9sel/inner.rs
@@ -350,13 +350,13 @@ impl<const SELECT1: bool, const SELECT0: bool> Rank9SelIndex<SELECT1, SELECT0> {
         let mut cur_rank = self.block_rank(block);
         debug_assert!(cur_rank <= k);
 
-        let rank_in_block_parallel = (k - cur_rank) * broadword::ONES_STEP_9;
-        let sub_ranks = self.sub_block_ranks(block);
-        let sub_block_offset = (broadword::uleq_step_9(sub_ranks, rank_in_block_parallel)
+        let rank_in_block_parallel = (k - cur_rank) as u64 * broadword::ONES_STEP_9;
+        let sub_ranks = self.sub_block_ranks(block) as u64;
+        let sub_block_offset = ((broadword::uleq_step_9(sub_ranks, rank_in_block_parallel)
             .wrapping_mul(broadword::ONES_STEP_9)
             >> 54)
-            & 0x7;
-        cur_rank += (sub_ranks >> (7 - sub_block_offset).wrapping_mul(9)) & 0x1FF;
+            & 0x7) as usize;
+        cur_rank += ((sub_ranks >> (7 - sub_block_offset).wrapping_mul(9)) & 0x1FF) as usize;
         debug_assert!(cur_rank <= k);
 
         let word_offset = block_offset + sub_block_offset;
@@ -423,13 +423,13 @@ impl<const SELECT1: bool, const SELECT0: bool> Rank9SelIndex<SELECT1, SELECT0> {
         let mut cur_rank = self.block_rank0(block);
         debug_assert!(cur_rank <= k);
 
-        let rank_in_block_parallel = (k - cur_rank) * broadword::ONES_STEP_9;
-        let sub_ranks = 64 * broadword::INV_COUNT_STEP_9 - self.sub_block_ranks(block);
-        let sub_block_offset = (broadword::uleq_step_9(sub_ranks, rank_in_block_parallel)
+        let rank_in_block_parallel = (k - cur_rank) as u64 * broadword::ONES_STEP_9;
+        let sub_ranks = 64u64 * broadword::INV_COUNT_STEP_9 - self.sub_block_ranks(block) as u64;
+        let sub_block_offset = ((broadword::uleq_step_9(sub_ranks, rank_in_block_parallel)
             .wrapping_mul(broadword::ONES_STEP_9)
             >> 54)
-            & 0x7;
-        cur_rank += (sub_ranks >> (7 - sub_block_offset).wrapping_mul(9)) & 0x1FF;
+            & 0x7) as usize;
+        cur_rank += ((sub_ranks >> (7 - sub_block_offset).wrapping_mul(9)) & 0x1FF) as usize;
         debug_assert!(cur_rank <= k);
 
         let word_offset = block_offset + sub_block_offset;
@@ -493,29 +493,6 @@ impl<const SELECT1: bool, const SELECT0: bool> Rank9SelIndex<SELECT1, SELECT0> {
             select0_hints,
         })
     }
-
-    /// Serializes the index metadata and data into a [`Bytes`] buffer.
-    pub fn to_bytes(&self) -> Bytes {
-        let mut store: Vec<usize> = Vec::new();
-        store.push(self.len);
-        store.push(self.block_rank_pairs.len());
-        store.extend_from_slice(self.block_rank_pairs.as_ref());
-        if let Some(ref v) = self.select1_hints {
-            store.push(1);
-            store.push(v.len());
-            store.extend_from_slice(v.as_ref());
-        } else {
-            store.push(0);
-        }
-        if let Some(ref v) = self.select0_hints {
-            store.push(1);
-            store.push(v.len());
-            store.extend_from_slice(v.as_ref());
-        } else {
-            store.push(0);
-        }
-        Bytes::from_source(store)
-    }
 }
 
 impl<const SELECT1: bool, const SELECT0: bool> crate::bit_vector::BitVectorIndex
@@ -552,15 +529,6 @@ impl<const SELECT1: bool, const SELECT0: bool> crate::bit_vector::BitVectorIndex
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_zero_copy_from_to_bytes() {
-        let data = BitVectorData::from_bits([false, true, true, false, true]);
-        let idx = Rank9SelIndex::<true, true>::new(&data);
-        let bytes = idx.to_bytes();
-        let other = Rank9SelIndex::<true, true>::from_bytes(bytes).unwrap();
-        assert_eq!(idx, other);
-    }
 
     #[test]
     fn test_builder_new_equivalence() {

--- a/src/char_sequences/mod.rs
+++ b/src/char_sequences/mod.rs
@@ -34,4 +34,4 @@
 //! For simplicity, the above table assumes constant-time and linear-space implementation.
 pub mod wavelet_matrix;
 
-pub use wavelet_matrix::WaveletMatrix;
+pub use wavelet_matrix::{WaveletMatrix, WaveletMatrixBuilder};

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -8,8 +8,10 @@ use num_traits::ToPrimitive;
 
 use crate::bit_vector::{self, BitVector, BitVectorBuilder, BitVectorIndex, Rank, Rank9SelIndex};
 use crate::int_vectors::{Access, Build, NumVals};
+use crate::serialization::Serializable;
 use crate::utils;
-use anybytes::{Bytes, View};
+use anybytes::{area::SectionHandle, ByteArea, Bytes, SectionWriter, View};
+use zerocopy::{FromBytes, Immutable};
 
 const LEVEL_WIDTH: usize = 8;
 const LEVEL_MASK: usize = (1 << LEVEL_WIDTH) - 1;
@@ -36,18 +38,20 @@ const MAX_LEVELS: usize = (usize::BITS as usize + LEVEL_WIDTH - 1) / LEVEL_WIDTH
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use jerky::int_vectors::{DacsByte, Access};
-///
+/// use anybytes::ByteArea;
+/// use jerky::int_vectors::{Access, DacsByte};
 /// use jerky::bit_vector::rank9sel::Rank9SelIndex;
-/// let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 0, 100000, 334])?;
+/// let mut area = ByteArea::new()?;
+/// let mut writer = area.sections();
+/// let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 0, 100000, 334], &mut writer)?;
+/// let meta = seq.metadata();
+/// let bytes = area.freeze()?; // finalize arena
+/// let other = DacsByte::<Rank9SelIndex>::from_bytes(meta, bytes.clone())?;
+/// assert_eq!(seq, other);
+/// assert_eq!(other.access(2), Some(100000));
 ///
-/// assert_eq!(seq.access(0), Some(5));
-/// assert_eq!(seq.access(1), Some(0));
-/// assert_eq!(seq.access(2), Some(100000));
-/// assert_eq!(seq.access(3), Some(334));
-///
-/// assert_eq!(seq.len(), 4);
-/// assert_eq!(seq.num_levels(), 3);
+/// assert_eq!(other.len(), 4);
+/// assert_eq!(other.num_levels(), 3);
 /// # Ok(())
 /// # }
 /// ```
@@ -56,49 +60,42 @@ const MAX_LEVELS: usize = (usize::BITS as usize + LEVEL_WIDTH - 1) / LEVEL_WIDTH
 ///
 /// - N. R. Brisaboa, S. Ladra, and G. Navarro, "DACs: Bringing direct access to variable-length
 ///   codes." Information Processing & Management, 49(1), 392-404, 2013.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct DacsByte<I = Rank9SelIndex> {
     data: Vec<View<[u8]>>,
     flags: Vec<BitVector<I>>,
+    handles: SectionHandle<LevelMeta>,
+}
+
+impl<I: PartialEq> PartialEq for DacsByte<I> {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+            && self.flags == other.flags
+            && self.handles.offset == other.handles.offset
+            && self.handles.len == other.handles.len
+    }
+}
+
+impl<I: Eq> Eq for DacsByte<I> {}
+
+/// Per-level metadata storing handles for payload bytes and flag bit vectors.
+#[derive(Debug, Clone, Copy, FromBytes, Immutable)]
+pub struct LevelMeta {
+    /// Handle to the level's payload bytes.
+    pub level: SectionHandle<u8>,
+    /// Handle to the flag bit vector words (empty for last level).
+    pub flag: SectionHandle<u64>,
+    /// Number of bits stored in the flag bit vector.
+    pub flag_bits: usize,
 }
 
 /// Metadata required to reconstruct a `DacsByte` from bytes.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub struct DacsByteMeta {
     /// Number of valid levels stored.
     pub num_levels: usize,
-    /// Byte length for each level in order.
-    pub level_lens: Vec<usize>,
-    /// Metadata for each flag bit vector between levels.
-    pub flag_meta: Vec<FlagMeta>,
-}
-
-/// Metadata describing a flag bit vector stored inside a `DacsByte`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FlagMeta {
-    /// Number of bits stored in the bit vector.
-    pub len_bits: usize,
-    /// Number of machine words used to hold the bits.
-    pub num_words: usize,
-}
-
-impl Default for FlagMeta {
-    fn default() -> Self {
-        Self {
-            len_bits: 0,
-            num_words: 0,
-        }
-    }
-}
-
-impl Default for DacsByteMeta {
-    fn default() -> Self {
-        Self {
-            num_levels: 0,
-            level_lens: Vec::new(),
-            flag_meta: Vec::new(),
-        }
-    }
+    /// Handle to a slice of per-level [`LevelMeta`] structures.
+    pub levels: SectionHandle<LevelMeta>,
 }
 
 impl<I: BitVectorIndex> DacsByte<I> {
@@ -107,18 +104,38 @@ impl<I: BitVectorIndex> DacsByte<I> {
     /// # Arguments
     ///
     /// - `vals`: Slice of integers to be stored.
+    /// - `writer`: Memory allocator used for all internal buffers.
     ///
     /// # Errors
     ///
     /// An error is returned if `vals` contains an integer that cannot be cast to [`usize`].
-    pub fn from_slice<T>(vals: &[T]) -> Result<Self>
+    pub fn from_slice<'a, T>(vals: &[T], writer: &mut SectionWriter<'a>) -> Result<Self>
     where
         T: ToPrimitive,
     {
         if vals.is_empty() {
-            return Ok(Self::default());
+            let data_sec = writer.reserve::<u8>(0)?;
+            let data_handle = data_sec.handle();
+            let flag_sec = writer.reserve::<u64>(0)?;
+            let flag_handle = flag_sec.handle();
+            let mut infos = writer.reserve::<LevelMeta>(1)?;
+            infos[0] = LevelMeta {
+                level: data_handle,
+                flag: flag_handle,
+                flag_bits: 0,
+            };
+            let handles = infos.handle();
+            infos.freeze()?;
+            flag_sec.freeze()?;
+            data_sec.freeze()?;
+            return Ok(Self {
+                data: vec![Bytes::empty().view::<[u8]>().unwrap()],
+                flags: vec![],
+                handles,
+            });
         }
 
+        // Determine the number of levels by scanning for the maximum value.
         let mut maxv = 0;
         for x in vals {
             maxv =
@@ -130,42 +147,119 @@ impl<I: BitVectorIndex> DacsByte<I> {
         let num_levels = utils::ceiled_divide(num_bits, LEVEL_WIDTH);
         assert_ne!(num_levels, 0);
 
+        // Single-level case: just reserve the bytes and return.
         if num_levels == 1 {
-            let data: Vec<_> = vals
-                .iter()
-                .map(|x| u8::try_from(x.to_usize().unwrap()).unwrap())
-                .collect();
+            let mut section = writer.reserve::<u8>(vals.len())?;
+            let slice = section.as_mut_slice();
+            for (i, x) in vals.iter().enumerate() {
+                slice[i] = u8::try_from(x.to_usize().unwrap()).unwrap();
+            }
+            let level_handle = section.handle();
+            let flag_sec = writer.reserve::<u64>(0)?;
+            let flag_handle = flag_sec.handle();
+            let mut infos = writer.reserve::<LevelMeta>(1)?;
+            infos[0] = LevelMeta {
+                level: level_handle,
+                flag: flag_handle,
+                flag_bits: 0,
+            };
+            let handles = infos.handle();
+            infos.freeze()?;
+            flag_sec.freeze()?;
+            let data = section.freeze()?.view::<[u8]>()?;
             return Ok(Self {
-                data: vec![Bytes::from_source(data).view::<[u8]>().unwrap()],
+                data: vec![data],
                 flags: vec![],
+                handles,
             });
         }
 
-        let mut data = vec![vec![]; num_levels];
-        let mut flags = vec![BitVectorBuilder::new(); num_levels - 1];
+        // First pass: count flags per level and determine payload lengths.
+        let mut flag_counts = vec![0usize; num_levels - 1];
+        let mut level_lens = vec![0usize; num_levels];
+        for val in vals {
+            let mut x = val
+                .to_usize()
+                .ok_or_else(|| anyhow!("vals must consist only of values castable into usize."))?;
+            let mut j = 0;
+            loop {
+                level_lens[j] += 1;
+                if j == num_levels - 1 {
+                    break;
+                }
+                x >>= LEVEL_WIDTH;
+                flag_counts[j] += 1;
+                if x == 0 {
+                    break;
+                }
+                j += 1;
+            }
+        }
+        // Allocate metadata table, level sections, flag builders, and a dummy flag handle.
+        let mut infos = writer.reserve::<LevelMeta>(num_levels)?;
+        let mut flags: Vec<BitVectorBuilder> = flag_counts
+            .iter()
+            .map(|&c| BitVectorBuilder::with_capacity(c, writer))
+            .collect::<Result<_, _>>()?;
+        let dummy_flag_sec = writer.reserve::<u64>(0)?;
+        let dummy_flag_handle = dummy_flag_sec.handle();
+        let mut levels: Vec<_> = level_lens
+            .iter()
+            .map(|&len| writer.reserve::<u8>(len))
+            .collect::<Result<_, _>>()?;
+        for j in 0..num_levels {
+            let mut meta = LevelMeta {
+                level: levels[j].handle(),
+                flag: dummy_flag_handle,
+                flag_bits: 0,
+            };
+            if j + 1 < num_levels {
+                meta.flag = flags[j].handle();
+                meta.flag_bits = flag_counts[j];
+            }
+            infos[j] = meta;
+        }
+        dummy_flag_sec.freeze()?;
 
-        for x in vals {
-            let mut x = x.to_usize().unwrap();
+        // Offsets for writing into levels and flags.
+        let mut level_offs = vec![0usize; num_levels];
+        let mut flag_offs = vec![0usize; num_levels - 1];
+
+        // Second pass: populate levels and flags in place.
+        for val in vals {
+            let mut x = val.to_usize().unwrap();
             for j in 0..num_levels {
-                data[j].push(u8::try_from(x & LEVEL_MASK).unwrap());
+                levels[j].as_mut_slice()[level_offs[j]] = u8::try_from(x & LEVEL_MASK).unwrap();
+                level_offs[j] += 1;
                 x >>= LEVEL_WIDTH;
                 if j == num_levels - 1 {
                     assert_eq!(x, 0);
                     break;
                 } else if x == 0 {
-                    flags[j].push_bit(false);
+                    flags[j].set_bit(flag_offs[j], false)?;
+                    flag_offs[j] += 1;
                     break;
+                } else {
+                    flags[j].set_bit(flag_offs[j], true)?;
+                    flag_offs[j] += 1;
                 }
-                flags[j].push_bit(true);
             }
         }
 
-        let flags = flags.into_iter().map(|bvb| bvb.freeze::<I>()).collect();
-        let data = data
+        // Freeze level sections, flag builders, and metadata table.
+        let data = levels
             .into_iter()
-            .map(|v| Bytes::from_source(v).view::<[u8]>().unwrap())
-            .collect();
-        Ok(Self { data, flags })
+            .map(|sec| sec.freeze()?.view::<[u8]>().map_err(|e| anyhow!(e)))
+            .collect::<Result<Vec<_>>>()?;
+        let flags = flags.into_iter().map(|bvb| bvb.freeze::<I>()).collect();
+        let handles = infos.handle();
+        infos.freeze()?;
+
+        Ok(Self {
+            data,
+            flags,
+            handles,
+        })
     }
 
     /// Creates an iterator for enumerating integers.
@@ -174,10 +268,14 @@ impl<I: BitVectorIndex> DacsByte<I> {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use anybytes::ByteArea;
     /// use jerky::bit_vector::rank9sel::Rank9SelIndex;
     /// use jerky::int_vectors::DacsByte;
     ///
-    /// let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 0, 100000, 334])?;
+    /// let mut area = ByteArea::new()?;
+    /// let mut writer = area.sections();
+    /// let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 0, 100000, 334], &mut writer)?;
+    /// area.freeze()?;
     /// let mut it = seq.iter();
     ///
     /// assert_eq!(it.next(), Some(5));
@@ -221,102 +319,86 @@ impl<I: BitVectorIndex> DacsByte<I> {
         self.data.iter().map(|_| LEVEL_WIDTH).collect()
     }
 
-    /// Serializes the sequence into a [`Bytes`] buffer.
-    ///
-    /// Returns the metadata necessary for [`from_bytes`].
-    pub fn to_bytes(&self) -> (DacsByteMeta, Bytes) {
-        let level_lens = self.data.iter().map(|v| v.len()).collect::<Vec<_>>();
-        let flag_meta = self
-            .flags
-            .iter()
-            .map(|f| FlagMeta {
-                len_bits: f.data.len,
-                num_words: f.data.num_words(),
-            })
-            .collect::<Vec<_>>();
-
-        let mut buf: Vec<u8> = Vec::new();
-        for flag in &self.flags {
-            for &word in flag.data.words.as_ref() {
-                buf.extend_from_slice(&word.to_ne_bytes());
-            }
-        }
-
-        for level in &self.data {
-            buf.extend_from_slice(level.as_ref());
-        }
-
-        (
-            DacsByteMeta {
-                num_levels: self.data.len(),
-                level_lens,
-                flag_meta,
-            },
-            Bytes::from_source(buf),
-        )
+    /// Returns metadata describing this sequence.
+    pub fn metadata(&self) -> DacsByteMeta {
+        <Self as Serializable>::metadata(self)
     }
 
     /// Reconstructs the sequence from zero-copy [`Bytes`].
-    ///
-    /// The `meta` argument should come from [`to_bytes`].
     pub fn from_bytes(meta: DacsByteMeta, bytes: Bytes) -> Result<Self> {
-        use std::mem::size_of;
+        <Self as Serializable>::from_bytes(meta, bytes)
+    }
+}
 
-        let usize_size = size_of::<usize>();
-        let mut cursor = 0;
-        let slice = bytes.as_ref();
+impl<I: BitVectorIndex> Serializable for DacsByte<I> {
+    type Meta = DacsByteMeta;
 
-        if meta.num_levels == 0
-            || meta.num_levels > MAX_LEVELS
-            || meta.level_lens.len() != meta.num_levels
-            || meta.flag_meta.len() != meta.num_levels.saturating_sub(1)
-        {
+    fn metadata(&self) -> Self::Meta {
+        DacsByteMeta {
+            num_levels: self.data.len(),
+            levels: self.handles,
+        }
+    }
+
+    fn from_bytes(meta: Self::Meta, bytes: Bytes) -> Result<Self> {
+        if meta.num_levels == 0 || meta.num_levels > MAX_LEVELS {
             return Err(anyhow!("invalid metadata"));
         }
 
-        let mut flags = Vec::with_capacity(meta.flag_meta.len());
-        for fm in &meta.flag_meta {
-            let bytes_len = fm.num_words * usize_size;
-            if cursor + bytes_len > slice.len() {
-                return Err(anyhow!("insufficient bytes"));
-            }
-            let words_view = bytes
-                .slice_to_bytes(&slice[cursor..cursor + bytes_len])
-                .ok_or_else(|| anyhow!("invalid slice"))?
-                .view::<[usize]>()
-                .map_err(|e| anyhow!(e))?;
-            cursor += bytes_len;
-            let data = bit_vector::BitVectorData {
-                words: words_view,
-                len: fm.len_bits,
-            };
-            let index = I::build(&data);
-            flags.push(bit_vector::BitVector { data, index });
+        let infos = meta.levels.view(&bytes).map_err(anyhow::Error::from)?;
+        if infos.as_ref().len() != meta.num_levels {
+            return Err(anyhow!("invalid metadata"));
         }
 
+        let mut flags = Vec::with_capacity(meta.num_levels.saturating_sub(1));
         let mut data = Vec::with_capacity(meta.num_levels);
-        for &len in &meta.level_lens {
-            if cursor + len > slice.len() {
-                return Err(anyhow!("insufficient bytes"));
+        for (idx, info) in infos.as_ref().iter().enumerate() {
+            if idx + 1 < meta.num_levels {
+                let words = info.flag.view(&bytes).map_err(anyhow::Error::from)?;
+                let bv_data = bit_vector::BitVectorData {
+                    words,
+                    len: info.flag_bits,
+                };
+                let index = I::build(&bv_data);
+                flags.push(bit_vector::BitVector {
+                    data: bv_data,
+                    index,
+                });
             }
-            let view_bytes = bytes
-                .slice_to_bytes(&slice[cursor..cursor + len])
-                .ok_or_else(|| anyhow!("invalid slice"))?;
-            let view = view_bytes.view::<[u8]>().map_err(|e| anyhow!(e))?;
-            data.push(view);
-            cursor += len;
+            let lvl_view = info.level.view(&bytes).map_err(anyhow::Error::from)?;
+            data.push(lvl_view);
         }
 
-        Ok(Self { data, flags })
+        Ok(Self {
+            data,
+            flags,
+            handles: meta.levels,
+        })
     }
 }
 
 impl<I: BitVectorIndex> Default for DacsByte<I> {
     fn default() -> Self {
+        let mut area = ByteArea::new().expect("byte area");
+        let mut writer = area.sections();
+        let data_sec = writer.reserve::<u8>(0).expect("reserve section");
+        let data_handle = data_sec.handle();
+        let flag_sec = writer.reserve::<u64>(0).expect("reserve flag");
+        let flag_handle = flag_sec.handle();
+        let mut infos = writer.reserve::<LevelMeta>(1).expect("reserve level meta");
+        infos[0] = LevelMeta {
+            level: data_handle,
+            flag: flag_handle,
+            flag_bits: 0,
+        };
+        let handles = infos.handle();
+        infos.freeze().expect("freeze level meta");
+        flag_sec.freeze().expect("freeze flag");
+        data_sec.freeze().expect("freeze section");
         Self {
-            // Needs a single level at least.
             data: vec![Bytes::empty().view::<[u8]>().unwrap()],
             flags: vec![],
+            handles,
         }
     }
 }
@@ -330,7 +412,12 @@ impl<I: BitVectorIndex> Build for DacsByte<I> {
         T: ToPrimitive,
         Self: Sized,
     {
-        Self::from_slice(vals)
+        let mut area = ByteArea::new()?;
+        let mut writer = area.sections();
+        let seq = Self::from_slice(vals, &mut writer)?;
+        // Ensure the area is sealed so the bytes become immutable.
+        area.freeze()?;
+        Ok(seq)
     }
 }
 
@@ -353,10 +440,14 @@ impl<I: BitVectorIndex> Access for DacsByte<I> {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use anybytes::ByteArea;
     /// use jerky::bit_vector::rank9sel::Rank9SelIndex;
     /// use jerky::int_vectors::{DacsByte, Access};
     ///
-    /// let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 999, 334])?;
+    /// let mut area = ByteArea::new()?;
+    /// let mut writer = area.sections();
+    /// let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 999, 334], &mut writer)?;
+    /// area.freeze()?;
     ///
     /// assert_eq!(seq.access(0), Some(5));
     /// assert_eq!(seq.access(1), Some(999));
@@ -429,12 +520,16 @@ impl<I: BitVectorIndex> Iterator for Iter<'_, I> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anybytes::Bytes;
+    use anybytes::{ByteArea, Bytes};
 
     #[test]
     fn test_basic() {
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
         let seq =
-            DacsByte::<Rank9SelIndex>::from_slice(&[0xFFFF, 0xFF, 0xF, 0xFFFFF, 0xF]).unwrap();
+            DacsByte::<Rank9SelIndex>::from_slice(&[0xFFFF, 0xFF, 0xF, 0xFFFFF, 0xF], &mut writer)
+                .unwrap();
+        area.freeze().unwrap();
 
         let expected = vec![
             Bytes::from_source(vec![0xFFu8, 0xFF, 0xF, 0xFF, 0xF])
@@ -447,11 +542,14 @@ mod tests {
         ];
         assert_eq!(seq.data, expected);
 
-        let mut b = BitVectorBuilder::new();
-        b.extend_bits([true, false, false, true, false]);
+        let mut area = ByteArea::new().unwrap();
+        let mut sections = area.sections();
+        let mut b = BitVectorBuilder::with_capacity(5, &mut sections).unwrap();
+        b.set_bit(0, true).unwrap();
+        b.set_bit(3, true).unwrap();
         let f0 = b.freeze::<Rank9SelIndex<true, true>>();
-        let mut b = BitVectorBuilder::new();
-        b.extend_bits([false, true]);
+        let mut b = BitVectorBuilder::with_capacity(2, &mut sections).unwrap();
+        b.set_bit(1, true).unwrap();
         let f1 = b.freeze::<Rank9SelIndex<true, true>>();
         assert_eq!(seq.flags, vec![f0, f1]);
 
@@ -469,7 +567,10 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let seq = DacsByte::<Rank9SelIndex>::from_slice::<usize>(&[]).unwrap();
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
+        let seq = DacsByte::<Rank9SelIndex>::from_slice::<usize>(&[], &mut writer).unwrap();
+        area.freeze().unwrap();
         assert!(seq.is_empty());
         assert_eq!(seq.len(), 0);
         assert_eq!(seq.num_levels(), 1);
@@ -478,7 +579,10 @@ mod tests {
 
     #[test]
     fn test_all_zeros() {
-        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[0, 0, 0, 0]).unwrap();
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
+        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[0, 0, 0, 0], &mut writer).unwrap();
+        area.freeze().unwrap();
         assert!(!seq.is_empty());
         assert_eq!(seq.len(), 4);
         assert_eq!(seq.num_levels(), 1);
@@ -491,28 +595,39 @@ mod tests {
 
     #[test]
     fn iter_collects() {
-        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 7]).unwrap();
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
+        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 7], &mut writer).unwrap();
+        area.freeze().unwrap();
         let collected: Vec<usize> = seq.iter().collect();
         assert_eq!(collected, vec![5, 7]);
     }
 
     #[test]
     fn to_vec_collects() {
-        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 7]).unwrap();
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
+        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 7], &mut writer).unwrap();
+        area.freeze().unwrap();
         assert_eq!(seq.to_vec(), vec![5, 7]);
     }
 
     #[test]
     fn bytes_roundtrip() {
-        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 0, 100000, 334]).unwrap();
-        let (meta, bytes) = seq.to_bytes();
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
+        let seq = DacsByte::<Rank9SelIndex>::from_slice(&[5, 0, 100000, 334], &mut writer).unwrap();
+        let bytes = area.freeze().unwrap();
+        let meta = seq.metadata();
         let other = DacsByte::<Rank9SelIndex>::from_bytes(meta, bytes).unwrap();
         assert_eq!(seq, other);
     }
 
     #[test]
     fn test_from_slice_uncastable() {
-        let e = DacsByte::<Rank9SelIndex>::from_slice(&[u128::MAX]);
+        let mut area = ByteArea::new().unwrap();
+        let mut writer = area.sections();
+        let e = DacsByte::<Rank9SelIndex>::from_slice(&[u128::MAX], &mut writer);
         assert_eq!(
             e.err().map(|x| x.to_string()),
             Some("vals must consist only of values castable into usize.".to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,12 @@ pub mod char_sequences;
 pub mod data;
 pub mod int_vectors;
 mod intrinsics;
+pub mod serialization;
 pub mod utils;
 
 pub use bit_vector::{BitVector, BitVectorData, BitVectorIndex, NoIndex};
 pub use data::IntVectorData;
+pub use serialization::Serializable;
 
 // NOTE(kampersanda): We should not use `get()` because it has been already used in most std
 // containers with different type annotations.

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,21 @@
+//! Zero-copy serialization utilities.
+
+use anybytes::Bytes;
+use anyhow::Result;
+
+/// Types that can be reconstructed from frozen [`Bytes`] using metadata.
+///
+/// Implementors write their data into a [`ByteArea`](anybytes::ByteArea) and
+/// expose lightweight metadata that describes where their bytes live. Given
+/// the metadata and the full `Bytes` region, the type can be rebuilt without
+/// copying.
+pub trait Serializable: Sized {
+    /// Metadata describing the byte layout required to reconstruct `Self`.
+    type Meta;
+
+    /// Returns metadata for this instance.
+    fn metadata(&self) -> Self::Meta;
+
+    /// Rebuilds an instance from metadata and the arena's frozen bytes.
+    fn from_bytes(meta: Self::Meta, bytes: Bytes) -> Result<Self>;
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ use crate::broadword;
 /// assert_eq!(needed_bits(256), 9);
 /// ```
 pub fn needed_bits(x: usize) -> usize {
-    broadword::msb(x).map_or(1, |n| n + 1)
+    broadword::msb(x as u64).map_or(1, |n| n + 1)
 }
 
 /// Returns `ceil(x / y)`.


### PR DESCRIPTION
## Summary
- show metadata-based reconstruction for `CompactVector` and `WaveletMatrix`
- add `dacs_byte` example and README snippet
- document `DacsByte::from_bytes` usage

## Testing
- `cargo test`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a8807536c8322849cb2c054b8eb12