### PR TITLE
Embed handles in BitVectorData and refactor serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Embedded section handles in `BitVectorData` and added `BitVectorDataMeta` with
+  `Serializable` support for both `BitVectorData` and `BitVector`, enabling
+  zero-copy reconstruction from arena metadata.
 - Introduced a `Serializable` trait for metadata-based reconstruction and
   implemented it for `CompactVector`, `DacsByte`, and `WaveletMatrix`.
 - Audited `DacsByte` and `WaveletMatrix` to leverage `SectionHandle::view`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -47,7 +47,6 @@
   manual offset math in complex `from_bytes` implementations like `DacsByte`.
 - Investigate slimming `DacsByte` per-level metadata to avoid storing unused
   flag handles for the last level.
-
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
 - Revisit zero-copy storage strategy: avoid extra copies when storing serialized bytes in structures.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ RUSTDOCFLAGS="--html-in-header katex.html" cargo doc --no-deps
 is backed by `anybytes::View`. Metadata describing a stored sequence includes
 [`SectionHandle`](anybytes::area::SectionHandle)s so the raw
 `Bytes` returned by `ByteArea::freeze` can be handed to
-`BitVectorData::from_bytes` for zero‑copy reconstruction.
+`BitVectorData::from_bytes` with its `BitVectorDataMeta` for zero‑copy reconstruction.
 
 Types following this pattern implement the [`Serializable`](src/serialization.rs) trait,
 which exposes a `metadata` accessor and a `from_bytes` constructor.

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -8,7 +8,8 @@ use anybytes::{area::SectionHandle, ByteArea, Bytes, Section, SectionWriter};
 use anyhow::{anyhow, Result};
 
 use crate::bit_vector::{
-    Access, BitVector, BitVectorBuilder, BitVectorData, BitVectorIndex, NumBits, Rank, Select,
+    Access, BitVector, BitVectorBuilder, BitVectorData, BitVectorDataMeta, BitVectorIndex, NumBits,
+    Rank, Select,
 };
 use crate::serialization::Serializable;
 use crate::utils;
@@ -806,11 +807,13 @@ impl<I: BitVectorIndex> Serializable for WaveletMatrix<I> {
         let handles_view = meta.layers.view(&bytes).map_err(anyhow::Error::from)?;
         let mut layers = Vec::with_capacity(meta.alph_width);
         for h in handles_view.as_ref() {
-            let words = h.view(&bytes).map_err(anyhow::Error::from)?;
-            let data = BitVectorData {
-                words,
-                len: meta.len,
-            };
+            let data = BitVectorData::from_bytes(
+                BitVectorDataMeta {
+                    len: meta.len,
+                    handle: *h,
+                },
+                bytes.clone(),
+            )?;
             let index = I::build(&data);
             layers.push(BitVector::new(data, index));
         }

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -354,16 +354,15 @@ impl<I: BitVectorIndex> Serializable for DacsByte<I> {
         let mut data = Vec::with_capacity(meta.num_levels);
         for (idx, info) in infos.as_ref().iter().enumerate() {
             if idx + 1 < meta.num_levels {
-                let words = info.flag.view(&bytes).map_err(anyhow::Error::from)?;
-                let bv_data = bit_vector::BitVectorData {
-                    words,
-                    len: info.flag_bits,
-                };
+                let bv_data = bit_vector::BitVectorData::from_bytes(
+                    bit_vector::BitVectorDataMeta {
+                        len: info.flag_bits,
+                        handle: info.flag,
+                    },
+                    bytes.clone(),
+                )?;
                 let index = I::build(&bv_data);
-                flags.push(bit_vector::BitVector {
-                    data: bv_data,
-                    index,
-                });
+                flags.push(bit_vector::BitVector::new(bv_data, index));
             }
             let lvl_view = info.level.view(&bytes).map_err(anyhow::Error::from)?;
             data.push(lvl_view);


### PR DESCRIPTION
## Summary
- embed section handles in `BitVectorData` with new `BitVectorDataMeta` and `Serializable` impls
- rebuild bit-vector users (`DacsByte`, `CompactVector`, `WaveletMatrix`) using `BitVectorData::from_bytes`
- refresh docs and inventory to match the new metadata layout

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b884d6189c8322b58020798fae9665