### PR TITLE
Add Metadata marker trait for zero-copy serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,5 @@
   `DacsByteMeta` to reference a single handle slice like `WaveletMatrixMeta`.
 - Expanded examples and README with `ByteArea`/`SectionHandle` metadata
   reconstruction for set-based APIs, adding a `dacs_byte` usage demo.
+- Added a `Metadata` marker trait to ensure metadata structs implement the
+  necessary zero-copy traits for safe byte serialization.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -47,6 +47,8 @@
   manual offset math in complex `from_bytes` implementations like `DacsByte`.
 - Investigate slimming `DacsByte` per-level metadata to avoid storing unused
   flag handles for the last level.
+- Provide a derive macro for the new `Metadata` trait to simplify implementing
+  zero-copy metadata structs.
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
 - Revisit zero-copy storage strategy: avoid extra copies when storing serialized bytes in structures.

--- a/src/bit_vector/mod.rs
+++ b/src/bit_vector/mod.rs
@@ -340,7 +340,8 @@ impl PartialEq for BitVectorData {
 impl Eq for BitVectorData {}
 
 /// Metadata describing a [`BitVectorData`] stored in a [`ByteArea`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, zerocopy::FromBytes, zerocopy::KnownLayout, zerocopy::Immutable)]
+#[repr(C)]
 pub struct BitVectorDataMeta {
     /// Number of bits stored.
     pub len: usize,

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -78,7 +78,8 @@ impl<I: PartialEq> PartialEq for WaveletMatrix<I> {
 impl<I: Eq> Eq for WaveletMatrix<I> {}
 
 /// Metadata describing the serialized form of a [`WaveletMatrix`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, zerocopy::FromBytes, zerocopy::KnownLayout, zerocopy::Immutable)]
+#[repr(C)]
 pub struct WaveletMatrixMeta {
     /// Maximum value + 1 stored in the matrix.
     pub alph_size: usize,

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -200,7 +200,8 @@ impl Default for CompactVector {
 }
 
 /// Metadata describing a [`CompactVector`] stored in a [`ByteArea`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, zerocopy::FromBytes, zerocopy::KnownLayout, zerocopy::Immutable)]
+#[repr(C)]
 pub struct CompactVectorMeta {
     /// Number of integers stored.
     pub len: usize,

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -11,7 +11,7 @@ use crate::int_vectors::{Access, Build, NumVals};
 use crate::serialization::Serializable;
 use crate::utils;
 use anybytes::{area::SectionHandle, ByteArea, Bytes, SectionWriter, View};
-use zerocopy::{FromBytes, Immutable};
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 const LEVEL_WIDTH: usize = 8;
 const LEVEL_MASK: usize = (1 << LEVEL_WIDTH) - 1;
@@ -79,7 +79,8 @@ impl<I: PartialEq> PartialEq for DacsByte<I> {
 impl<I: Eq> Eq for DacsByte<I> {}
 
 /// Per-level metadata storing handles for payload bytes and flag bit vectors.
-#[derive(Debug, Clone, Copy, FromBytes, Immutable)]
+#[derive(Debug, Clone, Copy, FromBytes, KnownLayout, Immutable)]
+#[repr(C)]
 pub struct LevelMeta {
     /// Handle to the level's payload bytes.
     pub level: SectionHandle<u8>,
@@ -90,7 +91,8 @@ pub struct LevelMeta {
 }
 
 /// Metadata required to reconstruct a `DacsByte` from bytes.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, FromBytes, KnownLayout, Immutable)]
+#[repr(C)]
 pub struct DacsByteMeta {
     /// Number of valid levels stored.
     pub num_levels: usize,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -3,6 +3,16 @@
 use anybytes::Bytes;
 use anyhow::Result;
 
+/// Marker trait for metadata structures that can be safely written to and
+/// read from bytes.
+///
+/// Types implementing this trait satisfy the requirements from `zerocopy` and
+/// `anybytes` for zero-copy serialization. It is automatically implemented for
+/// any type that implements the necessary `zerocopy` traits.
+pub trait Metadata: zerocopy::FromBytes + zerocopy::KnownLayout + zerocopy::Immutable {}
+
+impl<T> Metadata for T where T: zerocopy::FromBytes + zerocopy::KnownLayout + zerocopy::Immutable {}
+
 /// Types that can be reconstructed from frozen [`Bytes`] using metadata.
 ///
 /// Implementors write their data into a [`ByteArea`](anybytes::ByteArea) and
@@ -11,7 +21,7 @@ use anyhow::Result;
 /// copying.
 pub trait Serializable: Sized {
     /// Metadata describing the byte layout required to reconstruct `Self`.
-    type Meta;
+    type Meta: Metadata;
 
     /// Returns metadata for this instance.
     fn metadata(&self) -> Self::Meta;


### PR DESCRIPTION
## Summary
- add a `Metadata` marker trait requiring zerocopy traits
- derive zerocopy metadata traits for all meta structs
- bound `Serializable::Meta` with `Metadata`

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bddedc94d88322b06dc65527787945