### PR TITLE
Handle empty DacsByte length safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Prevent panic in `DacsByte::len` by handling empty level lists gracefully.
 - Embedded section handles in `BitVectorData` and added `BitVectorDataMeta` with
   `Serializable` support for both `BitVectorData` and `BitVector`, enabling
   zero-copy reconstruction from arena metadata.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -52,3 +52,4 @@
 ## Discovered Issues
 - `katex.html` performs manual string replacements; consider DOM-based manipulation.
 - Revisit zero-copy storage strategy: avoid extra copies when storing serialized bytes in structures.
+- Enforce that `DacsByte` always retains at least one level instead of relying on defensive length checks.

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -300,7 +300,7 @@ impl<I: BitVectorIndex> DacsByte<I> {
     /// Gets the number of integers.
     #[inline(always)]
     pub fn len(&self) -> usize {
-        self.data[0].len()
+        self.data.first().map_or(0, |lvl| lvl.len())
     }
 
     /// Checks if the vector is empty.


### PR DESCRIPTION
## Summary
- avoid panic in `DacsByte::len` by checking for missing levels
- record follow-up inventory item

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: unexpected formatting diffs in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b3aad4ec832296f429f855e1a631