### PR TITLE
Remove anyhow dependency and adopt crate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Removed the `anyhow` dependency in favor of crate-defined errors and updated
+  `Serializable` to expose an associated error type for reconstruction.
 - Prevent panic in `DacsByte::len` by handling empty level lists gracefully.
 - Embedded section handles in `BitVectorData` and added `BitVectorDataMeta` with
   `Serializable` support for both `BitVectorData` and `BitVector`, enabling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ rust-version = "1.61.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
 num-traits = "0.2.15"
 anybytes = { git = "https://github.com/triblespace/anybytes", features = ["zerocopy", "mmap"] }
 zerocopy = "0.8"

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -23,6 +23,9 @@
   common builder use cases.
 - Audit remaining constructors for zero-capacity variants and decide whether to
   offer explicit `empty` helpers instead of `with_capacity(0)`.
+- Evaluate introducing more structured error types per module now that
+  `anyhow` has been removed, ensuring diagnostics remain precise without
+  relying on free-form strings.
 - Allocate temporary wavelet-matrix buffers from `ByteArea` to avoid
   intermediate `Vec` copies and ensure fully contiguous construction.
 - Provide a derive or macro to reduce boilerplate when implementing the

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,12 +9,13 @@ pub struct IntVectorData {
 
 impl IntVectorData {
     /// Creates integer vector data from a slice of values.
-    pub fn from_slice<T: num_traits::ToPrimitive>(vals: &[T]) -> anyhow::Result<Self> {
+    pub fn from_slice<T: num_traits::ToPrimitive>(vals: &[T]) -> crate::error::Result<Self> {
         let mut ints = Vec::with_capacity(vals.len());
         for v in vals {
             ints.push(
-                v.to_usize()
-                    .ok_or_else(|| anyhow::anyhow!("vals must be castable"))?,
+                v.to_usize().ok_or_else(|| {
+                    crate::error::Error::invalid_argument("vals must be castable")
+                })?,
             );
         }
         Ok(Self { ints })

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,71 @@
+//! Common error types used throughout the crate.
+
+use std::fmt;
+
+use anybytes::view::ViewError;
+
+/// Result type used across the crate.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Error type covering failures across Jerky data structures.
+#[derive(Debug)]
+pub enum Error {
+    /// An argument violated preconditions.
+    InvalidArgument(String),
+    /// Deserialized metadata was malformed or inconsistent.
+    InvalidMetadata(String),
+    /// A mismatch between serialized hint flags and the requested type.
+    MismatchedHintFlags,
+    /// Wrapper around [`std::io::Error`] values.
+    Io(std::io::Error),
+    /// Wrapper around [`anybytes::ViewError`] values.
+    View(ViewError),
+}
+
+impl Error {
+    /// Creates an [`Error::InvalidArgument`] with the provided message.
+    pub fn invalid_argument(msg: impl Into<String>) -> Self {
+        Self::InvalidArgument(msg.into())
+    }
+
+    /// Creates an [`Error::InvalidMetadata`] with the provided message.
+    pub fn invalid_metadata(msg: impl Into<String>) -> Self {
+        Self::InvalidMetadata(msg.into())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidArgument(msg) => write!(f, "{msg}"),
+            Error::InvalidMetadata(msg) => write!(f, "{msg}"),
+            Error::MismatchedHintFlags => write!(f, "mismatched hint flags"),
+            Error::Io(err) => write!(f, "I/O error: {err}"),
+            Error::View(err) => write!(f, "view error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::InvalidArgument(_) | Error::InvalidMetadata(_) | Error::MismatchedHintFlags => {
+                None
+            }
+            Error::Io(err) => Some(err),
+            Error::View(err) => Some(err),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::Io(err)
+    }
+}
+
+impl From<ViewError> for Error {
+    fn from(err: ViewError) -> Self {
+        Error::View(err)
+    }
+}

--- a/src/int_vectors/mod.rs
+++ b/src/int_vectors/mod.rs
@@ -80,7 +80,7 @@ pub use compact_vector::CompactVector;
 pub use compact_vector::CompactVectorBuilder;
 pub use dacs_byte::DacsByte;
 
-use anyhow::Result;
+use crate::error::Result;
 use num_traits::ToPrimitive;
 
 /// Interface for building integer vectors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod bit_vector;
 pub mod broadword;
 pub mod char_sequences;
 pub mod data;
+pub mod error;
 pub mod int_vectors;
 mod intrinsics;
 pub mod serialization;
@@ -62,6 +63,7 @@ pub use bit_vector::BitVectorData;
 pub use bit_vector::BitVectorIndex;
 pub use bit_vector::NoIndex;
 pub use data::IntVectorData;
+pub use error::{Error, Result};
 pub use serialization::Serializable;
 
 // NOTE(kampersanda): We should not use `get()` because it has been already used in most std

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,7 +1,6 @@
 //! Zero-copy serialization utilities.
 
 use anybytes::Bytes;
-use anyhow::Result;
 
 /// Marker trait for metadata structures that can be safely written to and
 /// read from bytes.
@@ -22,10 +21,12 @@ impl<T> Metadata for T where T: zerocopy::FromBytes + zerocopy::KnownLayout + ze
 pub trait Serializable: Sized {
     /// Metadata describing the byte layout required to reconstruct `Self`.
     type Meta: Metadata;
+    /// Error type for reconstruction failures.
+    type Error: std::error::Error;
 
     /// Returns metadata for this instance.
     fn metadata(&self) -> Self::Meta;
 
     /// Rebuilds an instance from metadata and the arena's frozen bytes.
-    fn from_bytes(meta: Self::Meta, bytes: Bytes) -> Result<Self>;
+    fn from_bytes(meta: Self::Meta, bytes: Bytes) -> std::result::Result<Self, Self::Error>;
 }


### PR DESCRIPTION
## Summary
- add `src/error.rs` and re-export the crate-wide `Error`/`Result` helpers (`src/lib.rs`, `src/serialization.rs`)
- migrate bit-vector, integer-vector, and wavelet-matrix code to return the new error type and set their `Serializable::Error` associated types (`src/bit_vector/mod.rs`, `src/bit_vector/rank9sel/inner.rs`, `src/int_vectors/*`, `src/char_sequences/wavelet_matrix.rs`, `src/data.rs`)
- drop the `anyhow` dependency and document the change (`Cargo.toml`, `CHANGELOG.md`, `INVENTORY.md`)


------
https://chatgpt.com/codex/tasks/task_e_68d6ce73dd6c8322819731f0e5f4617a