### PR TITLE
Guard CompactVector deserialization against metadata overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Guarded `CompactVector::from_bytes` against metadata bit-length overflow.
 - Removed the `anyhow` dependency in favor of crate-defined errors and updated
   `Serializable` to expose an associated error type for reconstruction.
 - Prevent panic in `DacsByte::len` by handling empty level lists gracefully.


### PR DESCRIPTION
## Summary
- guard `CompactVector::from_bytes` against `len * width` overflow and return an `InvalidMetadata` error
- add a regression test that feeds overflowing metadata to ensure the guard triggers
- record the overflow protection in the changelog

## Testing
- cargo test
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6de6a9b808322b5b8d3108fbca6e7