### PR TITLE
Validate bit vector metadata length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Added metadata validation in `BitVectorData::from_bytes` to reject lengths
+  exceeding the stored capacity and covered the case with a regression test.
 - Removed the `anyhow` dependency in favor of crate-defined errors and updated
   `Serializable` to expose an associated error type for reconstruction.
 - Prevent panic in `DacsByte::len` by handling empty level lists gracefully.


### PR DESCRIPTION
## Summary
- reject oversized bit vector metadata lengths during deserialization by validating the capacity implied by the stored words
- add a regression test ensuring invalid metadata returns an error instead of panicking
- document the change in the changelog

## Testing
- cargo test
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6de5f6d048322b39509f7a428960d